### PR TITLE
添加内联app.toml文件的功能

### DIFF
--- a/spring/Cargo.toml
+++ b/spring/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[features]
+inline_file = []
+
 [dependencies]
 spring-macros = { path = "../spring-macros", version = "0.2.0" }
 anyhow = { workspace = true }
@@ -29,6 +32,7 @@ async-trait = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 dashmap = { workspace = true }
+rust-embed = { version = "8.5.0", features = ["interpolate-folder-path", "debug-embed"] }
 
 [dev-dependencies]
 tempfile = "3.12"

--- a/spring/src/config/toml.rs
+++ b/spring/src/config/toml.rs
@@ -88,7 +88,7 @@ impl TomlConfigRegistry {
         #[cfg(not(feature = "inline_file"))]
         let main_toml_str = get_config(config_path);
 
-        let main_table = toml::from_str::<Table>(main_toml_str.as_str())
+        let main_table = toml::from_str::<Table>(main_toml_str?.as_str())
             .with_context(|| format!("Failed to parse the toml file at path {:?}", config_path))?;
 
         let config_table: Table = match env.get_config_path(config_path) {


### PR DESCRIPTION
需要启用`inline_file`
如下：
```
spring = { path = "../spring", features = ["inline_file"] }
```
目前存在一定的不便，需要在spring库的位置创建./config/app.toml，才可把文件编译到二进制文件。
不开启不会有任何影响。

