### PR TITLE
添加内联app.toml文件的功能 

### DIFF
--- a/spring/Cargo.toml
+++ b/spring/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[features]
+inline_file = []
+
 [dependencies]
 spring-macros = { path = "../spring-macros", version = "0.2.0" }
 anyhow = { workspace = true }

--- a/spring/src/app.rs
+++ b/spring/src/app.rs
@@ -44,6 +44,7 @@ pub struct AppBuilder {
     /// task
     schedulers: Vec<Box<Scheduler<String>>>,
     shutdown_hooks: Vec<Box<Scheduler<String>>>,
+    pub inline_str: String,
 }
 
 impl App {
@@ -207,7 +208,7 @@ impl AppBuilder {
     /// This method returns the built App, and developers can implement logic such as command lines and task scheduling by themselves.
     async fn inner_run(&mut self) -> Result<Arc<App>> {
         // 1. load toml config
-        self.config = TomlConfigRegistry::new(&self.config_path, self.env)?;
+        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &*self.inline_str)?;
 
         // 2. build plugin
         self.build_plugins().await;
@@ -223,7 +224,7 @@ impl AppBuilder {
     /// This method returns the built App, and developers can implement logic such as command lines and task scheduling by themselves.
     pub async fn build(&mut self) -> Result<Arc<App>> {
         // 1. load toml config
-        self.config = TomlConfigRegistry::new(&self.config_path, self.env)?;
+        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &*self.inline_str)?;
 
         // 2. build plugin
         self.build_plugins().await;
@@ -304,6 +305,11 @@ impl AppBuilder {
             config,
         })
     }
+
+    pub fn use_config(&mut self, cfg: &str) -> std::result::Result<&mut AppBuilder, std::io::Error> {
+        self.inline_str = cfg.to_string();
+        Ok(self)
+    }
 }
 
 impl Default for AppBuilder {
@@ -317,6 +323,7 @@ impl Default for AppBuilder {
             components: Default::default(),
             schedulers: Default::default(),
             shutdown_hooks: Default::default(),
+            inline_str: Default::default(),
         }
     }
 }

--- a/spring/src/app.rs
+++ b/spring/src/app.rs
@@ -208,7 +208,7 @@ impl AppBuilder {
     /// This method returns the built App, and developers can implement logic such as command lines and task scheduling by themselves.
     async fn inner_run(&mut self) -> Result<Arc<App>> {
         // 1. load toml config
-        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &*self.inline_str)?;
+        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &self.inline_str)?;
 
         // 2. build plugin
         self.build_plugins().await;
@@ -224,7 +224,7 @@ impl AppBuilder {
     /// This method returns the built App, and developers can implement logic such as command lines and task scheduling by themselves.
     pub async fn build(&mut self) -> Result<Arc<App>> {
         // 1. load toml config
-        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &*self.inline_str)?;
+        self.config = TomlConfigRegistry::new(&self.config_path, self.env, &self.inline_str)?;
 
         // 2. build plugin
         self.build_plugins().await;

--- a/spring/src/config/toml.rs
+++ b/spring/src/config/toml.rs
@@ -72,7 +72,7 @@ impl TomlConfigRegistry {
         #[cfg(not(feature = "inline_file"))]
         let main_toml_str = get_profile(config_path)?;
 
-        let main_table = toml::from_str::<Table>(main_toml_str.as_str())
+        let main_table = toml::from_str::<Table>(&main_toml_str)
             .with_context(|| format!("Failed to parse the toml file at path {:?}", config_path))?;
 
         let config_table: Table = match env.get_config_path(config_path) {
@@ -124,7 +124,7 @@ mod tests {
         "#,
         );
 
-        let table = TomlConfigRegistry::new(&foo, Env::from_string("dev"))?;
+        let table = TomlConfigRegistry::new(&foo, Env::from_string("dev"), "")?;
         let group = table.get_by_prefix("group");
         assert_eq!(group.get("key").unwrap().as_str(), Some("A"));
 
@@ -137,7 +137,7 @@ mod tests {
         "#,
         );
 
-        let table = TomlConfigRegistry::new(&foo, Env::from_string("dev"))?;
+        let table = TomlConfigRegistry::new(&foo, Env::from_string("dev"), "")?;
         let group = table.get_by_prefix("group");
         assert_eq!(group.get("key").unwrap().as_str(), Some("OOOOA"));
 


### PR DESCRIPTION
需要启用inline_file
如下：
```toml
spring = { path = "../spring", features = ["inline_file"] }
```

用法：
```rs
let config_str = include_str!("../config/app.toml");
App::new().use_config(config_str).expect("REASON").add_plugin(WebPlugin).run().await;
```
此法可将"../config/app.toml"在编译时嵌入二进制文件，无需运行时读取，便于部署