### PR TITLE
docs: Fixed wrong filename for testing toml config

### DIFF
--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -52,7 +52,7 @@ port = 8000 # Configure the web service port. If not configured, the default por
 uri = "mysql://user:password@127.0.0.1:3306"
 ```
 
-`spring-rs` supports multiple environment configurations: dev (development), test (testing), and prod (production), corresponding to the three configuration files `app-dev.toml`, `app-dev.toml`, and `app-prod.toml`. The configuration in the environment configuration file will override the configuration items of the `app.toml` main configuration file.
+`spring-rs` supports multiple environment configurations: dev (development), test (testing), and prod (production), corresponding to the three configuration files `app-dev.toml`, `app-test.toml`, and `app-prod.toml`. The configuration in the environment configuration file will override the configuration items of the `app.toml` main configuration file.
 
 `spring-rs` will activate the configuration file of the corresponding environment according to the `SPRING_ENV` environment variable.
 

--- a/docs/content/docs/getting-started/quick-start.zh.md
+++ b/docs/content/docs/getting-started/quick-start.zh.md
@@ -98,7 +98,7 @@ port = 8000                  # 配置web服务端口，如果不配置默认就�
 uri = "mysql://user:password@127.0.0.1:3306"
 ```
 
-`spring-rs`支持多环境配置：dev(开发)、test(测试)、prod(生产)，分别对应着`app-dev.toml`、`app-dev.toml`、`app-prod.toml`三个配置文件。环境配置文件中的配置会覆盖`app.toml`主配置文件的配置项。
+`spring-rs`支持多环境配置：dev(开发)、test(测试)、prod(生产)，分别对应着`app-dev.toml`、`app-test.toml`、`app-prod.toml`三个配置文件。环境配置文件中的配置会覆盖`app.toml`主配置文件的配置项。
 
 `spring-rs`会根据`SPRING_ENV`环境变量激活对应环境的配置文件。
 
@@ -109,5 +109,3 @@ uri = "mysql://user:password@127.0.0.1:3306"
 ```sh
 cargo run
 ```
-
-


### PR DESCRIPTION
I found an error of toml config filename in the documentary. It should be `app-test.toml` instead of  `app-dev.toml` for testing config?