### PR TITLE
fix: :bug: update WebPlugin to allow dynamic route and middleware addition

### DIFF
--- a/spring-web/src/lib.rs
+++ b/spring-web/src/lib.rs
@@ -109,14 +109,18 @@ impl Plugin for WebPlugin {
             router = crate::middleware::apply_middleware(router, middlewares);
         }
 
+        app.add_component(router);
+
         let server_conf = config.server;
 
-        app.add_scheduler(move |app: Arc<App>| Box::new(Self::schedule(router, app, server_conf)));
+        app.add_scheduler(move |app: Arc<App>| Box::new(Self::schedule(app, server_conf)));
     }
 }
 
 impl WebPlugin {
-    async fn schedule(router: Router, app: Arc<App>, config: ServerConfig) -> Result<String> {
+    async fn schedule(app: Arc<App>, config: ServerConfig) -> Result<String> {
+        let router = app.get_expect_component::<Router>();
+
         // 2. bind tcp listener
         let addr = SocketAddr::from((config.binding, config.port));
         let listener = tokio::net::TcpListener::bind(addr)


### PR DESCRIPTION
Changed because this way we can create plugins that depend on the WebPlugin. With this approach, we can add new routes and middlewares directly from new plugins.

I noticed that creating plugins this way was not working because the schedule function only uses the first router (the one generated inside the WebPlugin) and doesn’t allow appending new things, this PR solve that.