### PR TITLE
refactor: simplify Postgres type definition by removing unnecessary struct and Deref implementation

### DIFF
--- a/spring-postgres/src/lib.rs
+++ b/spring-postgres/src/lib.rs
@@ -10,26 +10,10 @@ use spring::app::AppBuilder;
 use spring::async_trait;
 use spring::config::ConfigRegistry;
 use spring::plugin::{MutableComponentRegistry, Plugin};
-use std::ops::Deref;
 use std::sync::Arc;
 use tokio_postgres::NoTls;
 
-#[derive(Clone)]
-pub struct Postgres(Arc<tokio_postgres::Client>);
-
-impl Postgres {
-    fn new(client: tokio_postgres::Client) -> Self {
-        Self(Arc::new(client))
-    }
-}
-
-impl Deref for Postgres {
-    type Target = tokio_postgres::Client;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type Postgres = Arc<tokio_postgres::Client>;
 
 pub struct PgPlugin;
 


### PR DESCRIPTION
This change fix a little problem trying to create abstractions. A friend shares me this example which he was doing:

<details>

<summary>Example code:</summary>

```rust
use axum::Json;
use spring::app::AppBuilder;
use spring::async_trait;
use spring::plugin::{ComponentRegistry, Plugin};
use spring_postgres::{PgPlugin, Postgres};
use spring_web::extractor::Component;
use tokio_postgres::GenericClient;

struct EntityRepository<G: GenericClient>(pub G);
impl<G: GenericClient> Clone for EntityRepository<G> {
    fn clone(&self) -> Self {
        Self(self.0.clone())
    }
}

pub struct EntityPlugin;

#[async_trait]
impl Plugin for EntityPlugin {
    async fn build(&self, app: &mut AppBuilder) {
        let pg = app.get_component::<Postgres>().unwrap();
        /// Can't retrive ref or arc handle to tokio_postgres::Client;
        let client = *pg;
        EntityRepository(client);
    }
    fn dependencies(&self) -> Vec<&str> {
        vec![std::any::type_name::<PgPlugin>()]
    }
}

#[get_api("/entity")]
pub async fn list_users(Component(db): Component<Postgres>) -> Result<Json<Vec<User>>> {
    let transaction = db.transaction().await?;
    let repo = EntityRepository(transaction);
    EntityService::list(repo).await.map(Json)
}
```

</details>

This code currently it's not working because we are using a new type with the field in private, it's not exposed.

Besides, in this case, he is using the trait `GenericClient` for made trait bounds.