### PR TITLE
feat: add multi-datasource example for issue #192

### DIFF
--- a/examples/multi-datasource-example/.env
+++ b/examples/multi-datasource-example/.env
@@ -1,0 +1,2 @@
+PRIMARY_DATABASE_URL=postgres://postgres:xudjf23adj213@localhost/primary_db
+SECONDARY_DATABASE_URL=postgres://postgres:xudjf23adj213@localhost/secondary_db

--- a/examples/multi-datasource-example/Cargo.toml
+++ b/examples/multi-datasource-example/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "multi-datasource-example"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+spring = { path = "../../spring" }
+spring-web = { path = "../../spring-web" }
+spring-sea-orm = { path = "../../spring-sea-orm", features = [
+    "postgres",
+    "with-web",
+] }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+sea-orm = { workspace = true }
+serde = { workspace = true }

--- a/examples/multi-datasource-example/config/app.toml
+++ b/examples/multi-datasource-example/config/app.toml
@@ -1,0 +1,8 @@
+[multi-datasource.primary]
+uri = "${PRIMARY_DATABASE_URL}"
+enable_logging = true
+
+
+[multi-datasource.secondary]
+uri = "${SECONDARY_DATABASE_URL}"
+enable_logging = true

--- a/examples/multi-datasource-example/src/main.rs
+++ b/examples/multi-datasource-example/src/main.rs
@@ -1,0 +1,115 @@
+//! Multi-datasource Example
+//!
+//! This example demonstrates how to configure and use multiple database connections
+//! in a spring-rs application. This is useful for:
+//! - Read/Write splitting (primary for writes, secondary for reads)
+//! - Connecting to multiple different databases
+//! - Database sharding scenarios
+//!
+//! # Usage
+//!
+//! Set the environment variables before running:
+//! ```bash
+//! export PRIMARY_DATABASE_URL="postgres://user:pass@localhost:5432/primary_db"
+//! export SECONDARY_DATABASE_URL="postgres://user:pass@localhost:5432/secondary_db"
+//! cargo run -p multi-datasource-example
+//! ```
+
+mod multi_datasource;
+
+use anyhow::Context;
+use multi_datasource::{MultiDatasourcePlugin, PrimaryDb, SecondaryDb};
+use sea_orm::{ConnectionTrait, Statement};
+use spring::{auto_config, App};
+use spring_web::get;
+use spring_web::{
+    axum::response::IntoResponse, error::Result, extractor::Component, WebConfigurator, WebPlugin,
+};
+
+#[auto_config(WebConfigurator)]
+#[tokio::main]
+async fn main() {
+    App::new()
+        .add_plugin(MultiDatasourcePlugin)
+        .add_plugin(WebPlugin)
+        .run()
+        .await
+}
+
+/// Example handler that reads from the primary database
+#[get("/primary")]
+async fn query_primary(Component(db): Component<PrimaryDb>) -> Result<impl IntoResponse> {
+    // Example: Execute a simple query on the primary database
+    let result = db
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT 'Hello from Primary DB' as message".to_string(),
+        ))
+        .await
+        .context("query primary database failed")?;
+
+    let message = result
+        .map(|row| row.try_get::<String>("", "message").unwrap_or_default())
+        .unwrap_or_else(|| "No result".to_string());
+
+    Ok(message)
+}
+
+/// Example handler that reads from the secondary database
+#[get("/secondary")]
+async fn query_secondary(Component(db): Component<SecondaryDb>) -> Result<impl IntoResponse> {
+    // Example: Execute a simple query on the secondary database
+    let result = db
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT 'Hello from Secondary DB' as message".to_string(),
+        ))
+        .await
+        .context("query secondary database failed")?;
+
+    let message = result
+        .map(|row| row.try_get::<String>("", "message").unwrap_or_default())
+        .unwrap_or_else(|| "No result".to_string());
+
+    Ok(message)
+}
+
+/// Example handler that uses both databases
+/// This demonstrates a common read/write splitting pattern:
+/// - Write operations go to primary
+/// - Read operations go to secondary
+#[get("/both")]
+async fn query_both(
+    Component(primary): Component<PrimaryDb>,
+    Component(secondary): Component<SecondaryDb>,
+) -> Result<impl IntoResponse> {
+    // Query primary database
+    let primary_result = primary
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT current_database() as db_name".to_string(),
+        ))
+        .await
+        .context("query primary database failed")?;
+
+    let primary_db = primary_result
+        .map(|row| row.try_get::<String>("", "db_name").unwrap_or_default())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Query secondary database
+    let secondary_result = secondary
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT current_database() as db_name".to_string(),
+        ))
+        .await
+        .context("query secondary database failed")?;
+
+    let secondary_db = secondary_result
+        .map(|row| row.try_get::<String>("", "db_name").unwrap_or_default())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    Ok(format!(
+        "Primary DB: {primary_db}, Secondary DB: {secondary_db}"
+    ))
+}

--- a/examples/multi-datasource-example/src/multi_datasource.rs
+++ b/examples/multi-datasource-example/src/multi_datasource.rs
@@ -1,0 +1,103 @@
+//! Multi-datasource plugin example
+//!
+//! This module demonstrates how to configure multiple database connections
+//! using tuple structs to wrap different DbConn instances.
+
+use anyhow::Context;
+use serde::Deserialize;
+use spring::app::AppBuilder;
+use spring::config::{ConfigRegistry, Configurable};
+use spring::error::Result;
+use spring::plugin::{ComponentRegistry, MutableComponentRegistry, Plugin};
+use spring::{async_trait, tracing, App};
+use spring_sea_orm::config::SeaOrmConfig;
+use spring_sea_orm::{DbConn, SeaOrmPlugin};
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Primary database connection wrapper
+/// Use this for your main/primary database
+#[derive(Clone)]
+pub struct PrimaryDb(pub DbConn);
+
+impl Deref for PrimaryDb {
+    type Target = DbConn;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Secondary database connection wrapper
+/// Use this for your secondary/replica database
+#[derive(Clone)]
+pub struct SecondaryDb(pub DbConn);
+
+impl Deref for SecondaryDb {
+    type Target = DbConn;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Multi-datasource configuration
+/// Reuses SeaOrmConfig from spring-sea-orm for each datasource
+#[derive(Debug, Clone, Configurable, Deserialize)]
+#[config_prefix = "multi-datasource"]
+pub struct MultiDatasourceConfig {
+    pub primary: SeaOrmConfig,
+    pub secondary: SeaOrmConfig,
+}
+
+/// Multi-datasource plugin
+///
+/// This plugin initializes two database connections (primary and secondary)
+/// and registers them as separate components that can be injected into handlers.
+pub struct MultiDatasourcePlugin;
+
+#[async_trait]
+impl Plugin for MultiDatasourcePlugin {
+    async fn build(&self, app: &mut AppBuilder) {
+        let config = app
+            .get_config::<MultiDatasourceConfig>()
+            .expect("multi-datasource plugin config load failed");
+
+        // Connect to primary database
+        let primary_conn = SeaOrmPlugin::connect(&config.primary)
+            .await
+            .expect("primary database connection failed");
+        tracing::info!("Primary database connection established");
+
+        // Connect to secondary database
+        let secondary_conn = SeaOrmPlugin::connect(&config.secondary)
+            .await
+            .expect("secondary database connection failed");
+        tracing::info!("Secondary database connection established");
+
+        // Register both connections as components
+        app.add_component(PrimaryDb(primary_conn))
+            .add_component(SecondaryDb(secondary_conn))
+            .add_shutdown_hook(|app| Box::new(Self::close_connections(app)));
+    }
+}
+
+impl MultiDatasourcePlugin {
+    async fn close_connections(app: Arc<App>) -> Result<String> {
+        app.get_component::<PrimaryDb>()
+            .expect("primary db connection not exists")
+            .0
+            .close()
+            .await
+            .context("primary db close failed")?;
+
+        app.get_component::<SecondaryDb>()
+            .expect("secondary db connection not exists")
+            .0
+            .close()
+            .await
+            .context("secondary db close failed")?;
+
+        Ok("All database connections closed successfully".into())
+    }
+}


### PR DESCRIPTION
- Add MultiDatasourcePlugin for managing multiple database connections
- Support primary/secondary database configuration
- Reuse SeaOrmConfig from spring-sea-orm