### PR TITLE
feat(web): add global_prefix configuration for routing

### DIFF
--- a/examples/web-example/config/app.toml
+++ b/examples/web-example/config/app.toml
@@ -1,6 +1,7 @@
 [web]
 port = 8000
 graceful = true
+global_prefix = "/api"
 
 [web.openapi]
 doc_prefix = "/docs"

--- a/spring-web/README.md
+++ b/spring-web/README.md
@@ -27,6 +27,7 @@ binding = "172.20.10.4"  # IP address of the network interface to bind, default 
 port = 8000              # Port number to bind, default 8080
 connect_info = false     # Whether to use client connection information, default false
 graceful = true          # Whether to enable graceful shutdown, default false
+global_prefix = "api"    # Global prefix for all routes, default empty
 
 # Web middleware configuration
 [web.middlewares]

--- a/spring-web/README.zh.md
+++ b/spring-web/README.zh.md
@@ -27,6 +27,7 @@ binding = "172.20.10.4"  # 要绑定的网卡IP地址，默认0.0.0.0
 port = 8000              # 要绑定的端口号，默认8080
 connect_info = false     # 是否使用客户端连接信息，默认false
 graceful = true          # 是否开启优雅停机, 默认false
+global_prefix = "api"    # 所有路由的全局前缀，默认为空
 
 # web中间件配置
 [web.middlewares]

--- a/spring-web/src/config.rs
+++ b/spring-web/src/config.rs
@@ -30,6 +30,8 @@ pub struct ServerConfig {
     pub(crate) connect_info: bool,
     #[serde(default = "default_true")]
     pub(crate) graceful: bool,
+    #[serde(default)]
+    pub(crate) global_prefix: String,
 }
 
 #[cfg(feature = "openapi")]

--- a/spring-web/src/lib.rs
+++ b/spring-web/src/lib.rs
@@ -311,7 +311,12 @@ impl WebPlugin {
         };
 
         // 4. axum server
-        let router = router.layer(Extension(AppState { app }));
+        let mut router = router.layer(Extension(AppState { app }));
+
+        if !config.global_prefix.is_empty() {
+            router = axum::Router::new().nest(&config.global_prefix, router)
+        };
+
 
         tracing::info!("axum server started");
         if config.connect_info {


### PR DESCRIPTION
Based on the conversation on issue #201, this feature enables a global route for the endpoints