### PR TITLE
upgrade apalis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ repository = "https://github.com/spring-rs/spring-rs"
 [workspace.dependencies]
 aide = "0.16.0-alpha.1"
 anyhow = "1.0"
-apalis = "1.0.0-rc.2"
-apalis-redis = "1.0.0-rc.2"
-apalis-amqp = "1.0.0-rc.2"
-apalis-postgres = { version = "1.0.0-rc.2", default-features = false }
-apalis-mysql = { version = "1.0.0-rc.2", default-features = false }
-apalis-sqlite = { version = "1.0.0-rc.2", default-features = false }
-apalis-workflow = "0.1.0-rc.2"
-apalis-cron = "1.0.0-rc.2"
-apalis-board = "1.0.0-rc.2"
+apalis = "1.0.0-rc.3"
+apalis-redis = "1.0.0-rc.3"
+apalis-amqp = "1.0.0-rc.3"
+apalis-postgres = { version = "1.0.0-rc.3", default-features = false }
+apalis-mysql = { version = "1.0.0-rc.3", default-features = false }
+apalis-sqlite = { version = "1.0.0-rc.3", default-features = false }
+apalis-workflow = "0.1.0-rc.3"
+apalis-cron = "1.0.0-rc.3"
+apalis-board = "1.0.0-rc.3"
 async-trait = "0.1.81"
 axum = "0.8"
 byte-unit = "5.1"


### PR DESCRIPTION
- Update apalis from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-redis from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-amqp from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-postgres from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-mysql from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-sqlite from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-workflow from 0.1.0-rc.2 to 0.1.0-rc.3
- Update apalis-cron from 1.0.0-rc.2 to 1.0.0-rc.3
- Update apalis-board from 1.0.0-rc.2 to 1.0.0-rc.3