### PR TITLE
chore(examples): enable all features for plugin-example build depende…

### DIFF
--- a/examples/plugin-example/Cargo.toml
+++ b/examples/plugin-example/Cargo.toml
@@ -13,15 +13,27 @@ schemars = { workspace = true }
 
 [build-dependencies]
 spring = { path = "../../spring" }
-# generate plugin config schema
+# generate plugin config schema with all features enabled
+# Enable all features for apalis
+spring-apalis = { path = "../../spring-apalis", features = ["redis", "amqp", "sql-postgres", "sql-sqlite", "sql-mysql", "workflow", "board", "board-web"] }
 spring-grpc = { path = "../../spring-grpc" }
-spring-job = { path = "../../spring-job" }
+# Enable all features for job
+spring-job = { path = "../../spring-job", features = ["postgres_storage", "nats_storage"] }
 spring-mail = { path = "../../spring-mail" }
-spring-opendal = { path = "../../spring-opendal" }
-spring-opentelemetry = { path = "../../spring-opentelemetry" }
-spring-postgres = { path = "../../spring-postgres" }
+# Enable common services for opendal (not all to avoid compilation issues)
+spring-opendal = { path = "../../spring-opendal", features = ["services-fs", "services-memory", "services-s3", "services-oss", "services-cos", "services-azblob", "services-gcs", "services-obs", "layers-metrics", "layers-tracing"] }
+# Enable all features for opentelemetry
+spring-opentelemetry = { path = "../../spring-opentelemetry", features = ["jaeger", "zipkin", "more-resource", "grpc", "http"] }
+# Enable all features for postgres
+spring-postgres = { path = "../../spring-postgres", features = ["array-impls", "with-chrono-0_4", "with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
 spring-redis = { path = "../../spring-redis" }
-spring-sea-orm = { path = "../../spring-sea-orm" }
-spring-sqlx = { path = "../../spring-sqlx" }
-spring-stream = { path = "../../spring-stream" }
-spring-web = { path = "../../spring-web" }
+# Enable all features for sa-token
+spring-sa-token = { path = "../../spring-sa-token", features = ["memory", "with-web", "with-spring-redis", "openapi"] }
+# Enable all features for sea-orm
+spring-sea-orm = { path = "../../spring-sea-orm", features = ["with-web", "with-web-openapi", "mysql", "sqlite", "postgres"] }
+# Enable all features for sqlx
+spring-sqlx = { path = "../../spring-sqlx", features = ["postgres", "mysql", "sqlite", "with-json", "with-chrono", "with-rust_decimal", "with-bigdecimal", "with-uuid", "with-time"] }
+# Enable all features for stream
+spring-stream = { path = "../../spring-stream", features = ["kafka", "redis", "file", "stdio", "json"] }
+# Enable all features for web
+spring-web = { path = "../../spring-web", features = ["openapi", "openapi-redoc", "openapi-scalar", "openapi-swagger", "socket_io", "multipart", "ws"] }

--- a/examples/plugin-example/build.rs
+++ b/examples/plugin-example/build.rs
@@ -1,4 +1,5 @@
 pub fn main() {
+    let _ = spring_apalis::ApalisPlugin;
     let _ = spring_grpc::GrpcPlugin;
     let _ = spring_job::JobPlugin;
     let _ = spring_mail::MailPlugin;
@@ -8,6 +9,7 @@ pub fn main() {
     let _ = spring_redis::RedisPlugin;
     let _ = spring_sea_orm::SeaOrmPlugin;
     let _ = spring_sqlx::SqlxPlugin;
+    let _ = spring_sa_token::SaTokenPlugin;
     let _ = spring_stream::StreamPlugin;
     let _ = spring_web::WebPlugin;
 

--- a/spring-apalis/Cargo.toml
+++ b/spring-apalis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spring-apalis"
 description = "Integration of rust application framework spring-rs and apalis"
-version = "0.4.2"
+version = "0.4.3"
 categories = ["date-and-time"]
 keywords = ["cron-scheduler", "task-scheduling", "cron-job", "spring"]
 edition.workspace = true


### PR DESCRIPTION
…ncies

- Add spring-apalis with all features (redis, amqp, sql-postgres, sql-sqlite, sql-mysql, workflow, board, board-web)
- Enable all features for spring-job (postgres_storage, nats_storage)
- Enable common services for spring-opendal (fs, memory, s3, oss, cos, azblob, gcs, obs, metrics, tracing)
- Enable all features for spring-opentelemetry (jaeger, zipkin, more-resource, grpc, http)
- Enable all features for spring-postgres (array-impls, chrono, serde_json, time, uuid)
- Add spring-sa-token with all features (memory, with-web, with-spring-redis, openapi)
- Enable all features for spring-sea-orm (with-web, with-web-openapi, mysql, sqlite, postgres)
- Enable all features for spring-sqlx (postgres, mysql, sqlite, json, chrono, rust_decimal, bigdecimal, uuid, time)
- Enable all features for spring-stream (kafka, redis, file, stdio, json)
- Enable all features for spring-web (openapi, openapi-redoc, openapi-scalar, openapi-swagger, socket_io, multipart, ws)
- Add ApalisPlugin and SaTokenPlugin references to build.rs
- Bump spring-apalis version to 0.4.3
- Ensures comprehensive feature coverage for schema generation in plugin example