### PR TITLE
refactor(inventory): replace inventory::submit with submit_inventory …

### DIFF
--- a/spring/src/config/mod.rs
+++ b/spring/src/config/mod.rs
@@ -6,7 +6,6 @@ pub mod env;
 /// Implement reading toml configuration
 pub mod toml;
 
-pub use inventory::submit;
 pub use schemars::schema_for;
 pub use schemars::Schema;
 pub use spring_macros::Configurable;
@@ -66,7 +65,7 @@ inventory::collect!(ConfigSchema);
 #[macro_export]
 macro_rules! submit_config_schema {
     ($prefix:expr, $ty:ty) => {
-        ::spring::config::submit! {
+        ::spring::submit_inventory! {
             ::spring::config::ConfigSchema {
                 prefix: $prefix,
                 schema: || ::spring::config::schema_for!($ty),

--- a/spring/src/lib.rs
+++ b/spring/src/lib.rs
@@ -27,3 +27,4 @@ pub use spring_macros::auto_config;
 pub use spring_macros::component;
 pub use tracing;
 pub use tracing_error::SpanTrace;
+pub use inventory::submit as submit_inventory;

--- a/spring/src/log/config.rs
+++ b/spring/src/log/config.rs
@@ -9,7 +9,7 @@ impl Configurable for LoggerConfig {
     }
 }
 
-crate::config::submit! {
+crate::submit_inventory! {
     crate::config::ConfigSchema {
         prefix: "logger",
         schema: || crate::config::schema_for!(LoggerConfig),

--- a/spring/src/plugin/mod.rs
+++ b/spring/src/plugin/mod.rs
@@ -19,9 +19,6 @@ use std::{
     sync::Arc,
 };
 
-// Re-export inventory::submit for use in submit_component_plugin! macro
-pub use inventory::submit;
-
 // Define inventory collection for auto-registered plugins
 inventory::collect!(&'static dyn Plugin);
 
@@ -37,7 +34,7 @@ inventory::collect!(&'static dyn Plugin);
 #[macro_export]
 macro_rules! submit_component_plugin {
     ($ty:ident) => {
-        $crate::plugin::submit! {
+        $crate::submit_inventory! {
             &$ty as &dyn $crate::plugin::Plugin
         }
     };

--- a/spring/src/plugin/service.rs
+++ b/spring/src/plugin/service.rs
@@ -5,7 +5,6 @@ use crate::config::ConfigRegistry;
 use crate::error::Result;
 use crate::plugin::ComponentRegistry;
 
-pub use inventory::submit;
 pub use spring_macros::Service;
 
 /// Service is a special Component that can inject dependent Components as field members
@@ -39,7 +38,7 @@ inventory::collect!(&'static dyn ServiceRegistrar);
 #[macro_export]
 macro_rules! submit_service {
     ($ty:ident) => {
-        ::spring::plugin::service::submit! {
+        ::spring::submit_inventory! {
             &$ty as &dyn ::spring::plugin::service::ServiceRegistrar
         }
     };


### PR DESCRIPTION
…in multiple modules

- Update references from inventory::submit to submit_inventory in lib.rs, config/mod.rs, log/config.rs, plugin/mod.rs, and plugin/service.rs
- Ensure consistency in inventory submission across the codebase
- Improve clarity by using a more descriptive function name