### PR TITLE
Fix OpenAPI UI fetch URL missing global_prefix

### DIFF
--- a/summer-web/src/config.rs
+++ b/summer-web/src/config.rs
@@ -43,6 +43,27 @@ pub struct OpenApiConfig {
     pub(crate) info: aide::openapi::Info,
 }
 
+/// Normalize a URL prefix: ensure it starts with '/' and does not end with '/'.
+/// Empty strings are left unchanged.
+fn normalize_prefix(prefix: &mut String) {
+    if !prefix.is_empty() {
+        if !prefix.starts_with('/') {
+            prefix.insert(0, '/');
+        }
+        while prefix.ends_with('/') {
+            prefix.pop();
+        }
+    }
+}
+
+impl WebConfig {
+    pub(crate) fn normalize_prefixes(&mut self) {
+        normalize_prefix(&mut self.server.global_prefix);
+        #[cfg(feature = "openapi")]
+        normalize_prefix(&mut self.openapi.doc_prefix);
+    }
+}
+
 fn default_binding() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
 }

--- a/summer-web/src/lib.rs
+++ b/summer-web/src/lib.rs
@@ -238,9 +238,11 @@ pub struct WebPlugin;
 #[async_trait]
 impl Plugin for WebPlugin {
     async fn build(&self, app: &mut AppBuilder) {
-        let config = app
+        let mut config = app
             .get_config::<WebConfig>()
             .expect("web plugin config load failed");
+
+        config.normalize_prefixes();
 
         #[cfg(feature = "socket_io")]
         let socketio_config = app.get_config::<SocketIOConfig>().ok();
@@ -303,7 +305,7 @@ impl WebPlugin {
         #[cfg(feature = "openapi")]
         let router = {
             let openapi_conf = app.get_expect_component::<OpenApiConfig>();
-            finish_openapi(&app, router, openapi_conf)
+            finish_openapi(&app, router, openapi_conf, &config.global_prefix)
         };
 
         // 4. axum server
@@ -377,8 +379,9 @@ fn finish_openapi(
     app: &App,
     router: aide::axum::ApiRouter,
     openapi_conf: OpenApiConfig,
+    global_prefix: &str,
 ) -> axum::Router {
-    let router = router.nest_api_service(&openapi_conf.doc_prefix, docs_routes(&openapi_conf));
+    let router = router.nest_api_service(&openapi_conf.doc_prefix, docs_routes(&openapi_conf, global_prefix));
 
     let mut api = app.get_component::<OpenApi>().unwrap_or_else(|| OpenApi {
         info: openapi_conf.info,
@@ -391,13 +394,24 @@ fn finish_openapi(
         router.finish_api(&mut api)
     };
 
+    // Prepend global_prefix to all API paths in the OpenAPI spec,
+    // since finish_api() generates paths before nest(global_prefix) is applied.
+    if !global_prefix.is_empty() {
+        if let Some(ref mut paths) = api.paths {
+            let old_paths = std::mem::take(&mut paths.paths);
+            for (path, item) in old_paths {
+                paths.paths.insert(format!("{global_prefix}{path}"), item);
+            }
+        }
+    }
+
     router.layer(Extension(Arc::new(api)))
 }
 
 #[cfg(feature = "openapi")]
-pub fn docs_routes(OpenApiConfig { doc_prefix, info }: &OpenApiConfig) -> aide::axum::ApiRouter {
+pub fn docs_routes(OpenApiConfig { doc_prefix, info }: &OpenApiConfig, global_prefix: &str) -> aide::axum::ApiRouter {
     let router = aide::axum::ApiRouter::new();
-    let _openapi_path = &format!("{doc_prefix}/openapi.json");
+    let _openapi_path = &format!("{global_prefix}{doc_prefix}/openapi.json");
     let _doc_title = &info.title;
 
     #[cfg(feature = "openapi-scalar")]


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                                                                                        
  - Fix OpenAPI UI pages (Swagger, Scalar, Redoc) failing to load the OpenAPI spec when `global_prefix` is configured                                                                                                                                                                                                   
  - Fix OpenAPI spec API paths missing `global_prefix` (e.g., `/user/info` instead of `/api/user/info`)                                                                                                                                                                                                                 
  - Add unified prefix normalization (`normalize_prefixes()`) to ensure `global_prefix` and `doc_prefix` always start with `/` and never end with `/`                                                                                                                                                                   

  ## Root Cause

  When `global_prefix = "/api"` and `doc_prefix = "/docs"`:
  1. The UI fetch URL was `/docs/openapi.json` instead of `/api/docs/openapi.json` (404)
  2. The OpenAPI spec paths were `/user/info` instead of `/api/user/info`

  Both issues occur because `finish_api()` generates the spec before `nest(global_prefix)` is applied.

  ## Changes

  - **`spring-web/src/config.rs`**: Add `normalize_prefix()` helper and `WebConfig::normalize_prefixes()` method
  - **`spring-web/src/lib.rs`**:
    - Pass `global_prefix` to `docs_routes()` for correct UI fetch URL
    - After `finish_api()`, prepend `global_prefix` to all paths in the OpenAPI spec
    - Call `config.normalize_prefixes()` after config deserialization