### PR TITLE
feat(summer-sa-token): add Redis storage key prefix support

### DIFF
--- a/summer-sa-token/CHANGELOG.md
+++ b/summer-sa-token/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## 0.5.1
+
+- **added**: support `storage_prefix` for `with-summer-redis`, allowing Redis key namespacing such as `demo:sa:login:token:admin` ([#235])
+- **added**: support `rewrite_storage_prefix` for `with-summer-redis`, allowing `sa:login:token:admin` to be rewritten as `demo:login:token:admin` ([#235])
+- **changed**: normalize `storage_prefix` automatically so `demo` is treated as `demo:` ([#235])
+
 ## 0.5.0
 
 - **changed**: upgrade `summer` 0.4 to 0.5 ([#217])
 
 [#217]: https://github.com/summer-rs/summer-rs/pull/217
+[#235]: https://github.com/summer-rs/summer-rs/issues/235
 
 ## 0.4.2
 

--- a/summer-sa-token/Cargo.toml
+++ b/summer-sa-token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "summer-sa-token"
 description = "Sa-Token authentication and authorization plugin for summer-rs"
-version = "0.5.0"
+version = "0.5.1"
 categories = ["authentication", "web-programming"]
 keywords = ["authentication", "authorization", "sa-token", "summer", "security"]
 edition.workspace = true

--- a/summer-sa-token/README.md
+++ b/summer-sa-token/README.md
@@ -49,6 +49,17 @@ token_style = "Uuid"
 # Token prefix (e.g., "Bearer ")
 token_prefix = "Bearer "
 
+# Optional Redis storage prefix (only effective with `with-summer-redis`)
+# A trailing `:` is optional and will be normalized automatically.
+# When rewrite_storage_prefix = false:
+#   `sa:login:token:admin` -> `demo:sa:login:token:admin`
+# When rewrite_storage_prefix = true:
+#   `sa:login:token:admin` -> `demo:login:token:admin`
+storage_prefix = "demo"
+
+# Rewrite the built-in `sa:` storage root when a storage prefix is configured
+rewrite_storage_prefix = false
+
 # JWT configuration (only when token_style = "Jwt")
 jwt_secret_key = "your-secret-key"
 jwt_algorithm = "HS256"    # HS256, HS384, HS512
@@ -63,6 +74,26 @@ nonce_timeout = 300
 enable_refresh_token = false
 refresh_token_timeout = 604800  # 7 days
 ```
+
+When using `with-summer-redis`, `storage_prefix` can be used to namespace all
+Sa-Token Redis keys. This is useful when multiple applications share the same
+Redis instance and you want to avoid key collisions.
+
+This behavior is constrained by upstream `sa-token-core`: its logical storage
+root `sa:` is hardcoded and is not exposed as a configurable option. Because of
+that, `summer-sa-token` can only adjust the physical Redis keys at the storage
+adapter boundary.
+
+If `storage_prefix` does not end with `:`, `summer-sa-token` will add it
+automatically. For example, `demo` is normalized to `demo:`.
+
+- `rewrite_storage_prefix = false`:
+  prefixes keys without changing the built-in `sa:` root
+- `rewrite_storage_prefix = true`:
+  rewrites the built-in `sa:` root to your configured prefix
+
+Switching between these two modes changes the physical Redis key names, so
+existing login/session/token data will not be reused across the mode switch.
 
 ## Quick Start
 

--- a/summer-sa-token/README.zh.md
+++ b/summer-sa-token/README.zh.md
@@ -49,6 +49,17 @@ token_style = "Uuid"
 # Token 前缀（如 "Bearer "）
 token_prefix = "Bearer "
 
+# Redis 存储前缀（仅在 `with-summer-redis` 时生效）
+# 结尾不带 `:` 也可以，summer-sa-token 会自动规范成 `demo:`
+# rewrite_storage_prefix = false 时：
+#   `sa:login:token:admin` -> `demo:sa:login:token:admin`
+# rewrite_storage_prefix = true 时：
+#   `sa:login:token:admin` -> `demo:login:token:admin`
+storage_prefix = "demo"
+
+# 当配置了 storage_prefix 时，是否重写内建的 `sa:` 根前缀
+rewrite_storage_prefix = false
+
 # JWT 配置（仅当 token_style = "Jwt" 时需要）
 jwt_secret_key = "your-secret-key"
 jwt_algorithm = "HS256"    # HS256, HS384, HS512
@@ -63,6 +74,25 @@ nonce_timeout = 300
 enable_refresh_token = false
 refresh_token_timeout = 604800  # 7 天
 ```
+
+当使用 `with-summer-redis` 时，可以通过 `storage_prefix` 为所有 Sa-Token
+Redis key 增加统一命名空间。多个应用共用同一个 Redis 实例时，这样可以避免
+key 冲突。
+
+这里也受上游 `sa-token-core` 的限制：它把逻辑存储根前缀 `sa:` 直接硬编码了，
+并且没有对外提供配置项。因此 `summer-sa-token` 只能在存储适配层对最终的
+Redis 物理 key 做“追加前缀”或“重写前缀”。
+
+如果 `storage_prefix` 结尾没有 `:`，`summer-sa-token` 会自动补上。比如
+`demo` 会被规范成 `demo:`。
+
+- `rewrite_storage_prefix = false`：
+  只是在原始 `sa:` key 前面追加一层前缀
+- `rewrite_storage_prefix = true`：
+  直接把内建的 `sa:` 根前缀重写成你配置的前缀
+
+这两种模式的 Redis 物理 key 不兼容，切换模式后，旧的登录态 / session /
+token 数据不会被继续复用。
 
 
 ## 快速开始

--- a/summer-sa-token/src/config.rs
+++ b/summer-sa-token/src/config.rs
@@ -2,9 +2,9 @@
 //!
 //! This module defines the configuration for summer-sa-token plugin.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use summer::config::Configurable;
-use schemars::JsonSchema;
 // Re-export CoreConfig from upstream
 pub use sa_token_core::config::SaTokenConfig as CoreConfig;
 
@@ -126,6 +126,20 @@ pub struct SaTokenConfig {
     #[serde(default)]
     pub token_prefix: Option<String>,
 
+    /// Optional storage key prefix for namespacing Sa-Token keys in Redis.
+    #[serde(default)]
+    pub storage_prefix: Option<String>,
+
+    /// Rewrite the default `sa:` storage root when `storage_prefix` is set.
+    ///
+    /// When disabled:
+    /// - `sa:login:token:admin` -> `demo:sa:login:token:admin`
+    ///
+    /// When enabled:
+    /// - `sa:login:token:admin` -> `demo:login:token:admin`
+    #[serde(default)]
+    pub rewrite_storage_prefix: bool,
+
     /// JWT secret key
     #[serde(default)]
     pub jwt_secret_key: Option<String>,
@@ -179,6 +193,8 @@ impl Default for SaTokenConfig {
             is_read_header: true,
             is_read_body: false,
             token_prefix: None,
+            storage_prefix: None,
+            rewrite_storage_prefix: false,
             jwt_secret_key: None,
             jwt_algorithm: default_jwt_algorithm(),
             jwt_issuer: None,

--- a/summer-sa-token/src/configurator.rs
+++ b/summer-sa-token/src/configurator.rs
@@ -41,9 +41,9 @@
 
 use sa_token_adapter::storage::SaStorage;
 use sa_token_core::router::PathAuthConfig;
+use std::sync::Arc;
 use summer::app::AppBuilder;
 use summer::plugin::MutableComponentRegistry;
-use std::sync::Arc;
 
 /// Trait for configuring Sa-Token path-based authentication
 ///

--- a/summer-sa-token/src/custom_storage.rs
+++ b/summer-sa-token/src/custom_storage.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use summer::async_trait;
 use sa_token_adapter::storage::{SaStorage, StorageResult};
+use summer::async_trait;
 use summer::plugin::LazyComponent;
 
 /// Custom Sa-Token storage component wrapper.
@@ -90,93 +90,106 @@ impl<T: Clone + Send + Sync + 'static> LazyStorageWrapper<T> {
 #[async_trait]
 impl<T: SaStorage + Clone + Send + Sync + 'static> SaStorage for LazyStorageWrapper<T> {
     async fn get(&self, key: &str) -> StorageResult<Option<String>> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.get(key).await
     }
 
     async fn set(&self, key: &str, value: &str, ttl: Option<Duration>) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.set(key, value, ttl).await
     }
 
     async fn delete(&self, key: &str) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.delete(key).await
     }
 
     async fn exists(&self, key: &str) -> StorageResult<bool> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.exists(key).await
     }
 
     async fn expire(&self, key: &str, ttl: Duration) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.expire(key, ttl).await
     }
 
     async fn ttl(&self, key: &str) -> StorageResult<Option<Duration>> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.ttl(key).await
     }
 
     async fn mget(&self, keys: &[&str]) -> StorageResult<Vec<Option<String>>> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.mget(keys).await
     }
 
     async fn mset(&self, items: &[(&str, &str)], ttl: Option<Duration>) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.mset(items, ttl).await
     }
 
     async fn mdel(&self, keys: &[&str]) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.mdel(keys).await
     }
 
     async fn incr(&self, key: &str) -> StorageResult<i64> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.incr(key).await
     }
 
     async fn decr(&self, key: &str) -> StorageResult<i64> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.decr(key).await
     }
 
     async fn clear(&self) -> StorageResult<()> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.clear().await
     }
 
     async fn keys(&self, pattern: &str) -> StorageResult<Vec<String>> {
-        let storage = self.inner.get().map_err(|e| {
-            sa_token_adapter::storage::StorageError::OperationFailed(e.to_string())
-        })?;
+        let storage = self
+            .inner
+            .get()
+            .map_err(|e| sa_token_adapter::storage::StorageError::OperationFailed(e.to_string()))?;
         storage.keys(pattern).await
     }
 }

--- a/summer-sa-token/src/lib.rs
+++ b/summer-sa-token/src/lib.rs
@@ -3,10 +3,9 @@
 #![doc(html_favicon_url = "https://summer-rs.github.io/favicon.ico")]
 #![doc(html_logo_url = "https://summer-rs.github.io/logo.svg")]
 
-
-mod custom_storage;
 mod config;
 mod configurator;
+mod custom_storage;
 mod prelude;
 #[cfg(feature = "with-summer-redis")]
 pub mod storage;
@@ -170,7 +169,11 @@ impl SaTokenPlugin {
         {
             if let Some(redis) = app.get_component::<summer_redis::Redis>() {
                 tracing::info!("Using SummerRedisStorage (reusing summer-redis connection)");
-                let storage = storage::SummerRedisStorage::new(redis);
+                let storage = storage::SummerRedisStorage::new(
+                    redis,
+                    config.storage_prefix.clone(),
+                    config.rewrite_storage_prefix,
+                );
                 Ok(std::sync::Arc::new(storage))
             } else {
                 anyhow::bail!(

--- a/summer-sa-token/src/storage.rs
+++ b/summer-sa-token/src/storage.rs
@@ -4,10 +4,10 @@
 //! from `summer-redis` plugin, avoiding duplicate connections.
 
 use sa_token_adapter::storage::{SaStorage, StorageError, StorageResult};
+use std::time::Duration;
 use summer::async_trait;
 use summer_redis::redis::AsyncCommands;
 use summer_redis::Redis;
-use std::time::Duration;
 
 /// Redis storage implementation using summer-redis connection
 ///
@@ -15,12 +15,73 @@ use std::time::Duration;
 /// so you don't need to configure a separate Redis connection for sa-token.
 pub struct SummerRedisStorage {
     client: Redis,
+    prefix: Option<String>,
+    rewrite_prefix: bool,
 }
 
 impl SummerRedisStorage {
     /// Create a new SummerRedisStorage with the given Redis connection
-    pub fn new(client: Redis) -> Self {
-        Self { client }
+    pub fn new(client: Redis, prefix: Option<String>, rewrite_prefix: bool) -> Self {
+        let prefix = normalize_storage_prefix(prefix);
+        Self {
+            client,
+            prefix,
+            rewrite_prefix,
+        }
+    }
+}
+
+fn normalize_storage_prefix(prefix: Option<String>) -> Option<String> {
+    match prefix {
+        Some(prefix) if prefix.is_empty() => None,
+        Some(prefix) if prefix.ends_with(':') => Some(prefix),
+        Some(prefix) => Some(format!("{prefix}:")),
+        None => None,
+    }
+}
+
+fn apply_storage_prefix(prefix: Option<&str>, rewrite_prefix: bool, key: &str) -> String {
+    match prefix {
+        Some(prefix) if !prefix.is_empty() && rewrite_prefix => {
+            // Upstream sa-token-core hardcodes the logical storage root as `sa:`
+            // and does not expose a configuration hook for it, so the adapter can
+            // only rewrite that prefix at the storage boundary.
+            if let Some(stripped) = key.strip_prefix("sa:") {
+                format!("{prefix}{stripped}")
+            } else {
+                format!("{prefix}{key}")
+            }
+        }
+        Some(prefix) if !prefix.is_empty() => format!("{prefix}{key}"),
+        _ => key.to_string(),
+    }
+}
+
+fn apply_storage_prefix_to_pattern(
+    prefix: Option<&str>,
+    rewrite_prefix: bool,
+    pattern: &str,
+) -> String {
+    apply_storage_prefix(prefix, rewrite_prefix, pattern)
+}
+
+fn strip_storage_prefix(prefix: Option<&str>, rewrite_prefix: bool, key: &str) -> String {
+    match prefix {
+        Some(prefix) if !prefix.is_empty() && rewrite_prefix => {
+            if let Some(stripped) = key.strip_prefix(prefix) {
+                // Restore the upstream logical `sa:` key shape before returning
+                // values to sa-token-core, which still expects its hardcoded root.
+                if stripped.starts_with("sa:") {
+                    stripped.to_string()
+                } else {
+                    format!("sa:{stripped}")
+                }
+            } else {
+                key.to_string()
+            }
+        }
+        Some(prefix) if !prefix.is_empty() => key.strip_prefix(prefix).unwrap_or(key).to_string(),
+        _ => key.to_string(),
     }
 }
 
@@ -28,6 +89,7 @@ impl SummerRedisStorage {
 impl SaStorage for SummerRedisStorage {
     async fn get(&self, key: &str) -> StorageResult<Option<String>> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
         tracing::debug!("SummerRedisStorage GET key: {}", key);
         conn.get(key)
             .await
@@ -36,6 +98,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn set(&self, key: &str, value: &str, ttl: Option<Duration>) -> StorageResult<()> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
         tracing::debug!("SummerRedisStorage SET key: {}", key);
 
         if let Some(ttl) = ttl {
@@ -51,6 +114,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn delete(&self, key: &str) -> StorageResult<()> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         conn.del(key)
             .await
@@ -59,6 +123,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn exists(&self, key: &str) -> StorageResult<bool> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         conn.exists(key)
             .await
@@ -67,6 +132,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn expire(&self, key: &str, ttl: Duration) -> StorageResult<()> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         conn.expire(key, ttl.as_secs() as i64)
             .await
@@ -75,6 +141,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn ttl(&self, key: &str) -> StorageResult<Option<Duration>> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         let ttl_secs: i64 = conn
             .ttl(key)
@@ -91,6 +158,10 @@ impl SaStorage for SummerRedisStorage {
 
     async fn mget(&self, keys: &[&str]) -> StorageResult<Vec<Option<String>>> {
         let mut conn = self.client.clone();
+        let keys: Vec<String> = keys
+            .iter()
+            .map(|key| apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key))
+            .collect();
 
         // Use mget command for multiple keys
         summer_redis::redis::cmd("MGET")
@@ -106,10 +177,11 @@ impl SaStorage for SummerRedisStorage {
         // Use pipeline for batch operations
         let mut pipe = summer_redis::redis::pipe();
         for (key, value) in items {
+            let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
             if let Some(ttl) = ttl {
-                pipe.set_ex(*key, *value, ttl.as_secs());
+                pipe.set_ex(key, *value, ttl.as_secs());
             } else {
-                pipe.set(*key, *value);
+                pipe.set(key, *value);
             }
         }
 
@@ -120,6 +192,10 @@ impl SaStorage for SummerRedisStorage {
 
     async fn mdel(&self, keys: &[&str]) -> StorageResult<()> {
         let mut conn = self.client.clone();
+        let keys: Vec<String> = keys
+            .iter()
+            .map(|key| apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key))
+            .collect();
 
         conn.del(keys)
             .await
@@ -128,6 +204,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn incr(&self, key: &str) -> StorageResult<i64> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         conn.incr(key, 1)
             .await
@@ -136,6 +213,7 @@ impl SaStorage for SummerRedisStorage {
 
     async fn decr(&self, key: &str) -> StorageResult<i64> {
         let mut conn = self.client.clone();
+        let key = apply_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, key);
 
         conn.decr(key, 1)
             .await
@@ -144,7 +222,8 @@ impl SaStorage for SummerRedisStorage {
 
     async fn clear(&self) -> StorageResult<()> {
         let mut conn = self.client.clone();
-        let pattern = "sa:*";
+        let pattern =
+            apply_storage_prefix_to_pattern(self.prefix.as_deref(), self.rewrite_prefix, "sa:*");
 
         // Get all matching keys
         let keys: Vec<String> = conn
@@ -163,9 +242,88 @@ impl SaStorage for SummerRedisStorage {
 
     async fn keys(&self, pattern: &str) -> StorageResult<Vec<String>> {
         let mut conn = self.client.clone();
+        let pattern =
+            apply_storage_prefix_to_pattern(self.prefix.as_deref(), self.rewrite_prefix, pattern);
 
-        conn.keys(pattern)
+        let keys: Vec<String> = conn
+            .keys(pattern)
             .await
-            .map_err(|e| StorageError::OperationFailed(e.to_string()))
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(keys
+            .into_iter()
+            .map(|key| strip_storage_prefix(self.prefix.as_deref(), self.rewrite_prefix, &key))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_storage_prefix, apply_storage_prefix_to_pattern, normalize_storage_prefix,
+        strip_storage_prefix,
+    };
+
+    #[test]
+    fn normalizes_storage_prefix() {
+        assert_eq!(
+            normalize_storage_prefix(Some("demo".to_string())),
+            Some("demo:".to_string())
+        );
+        assert_eq!(
+            normalize_storage_prefix(Some("demo:".to_string())),
+            Some("demo:".to_string())
+        );
+        assert_eq!(normalize_storage_prefix(Some(String::new())), None);
+        assert_eq!(normalize_storage_prefix(None), None);
+    }
+
+    #[test]
+    fn applies_prefix_to_key() {
+        assert_eq!(
+            apply_storage_prefix(Some("demo:"), false, "sa:token:abc"),
+            "demo:sa:token:abc"
+        );
+        assert_eq!(
+            apply_storage_prefix(Some("demo:"), true, "sa:token:abc"),
+            "demo:token:abc"
+        );
+        assert_eq!(
+            apply_storage_prefix(None, false, "sa:token:abc"),
+            "sa:token:abc"
+        );
+    }
+
+    #[test]
+    fn applies_prefix_to_pattern() {
+        assert_eq!(
+            apply_storage_prefix_to_pattern(Some("demo:"), false, "sa:*"),
+            "demo:sa:*"
+        );
+        assert_eq!(
+            apply_storage_prefix_to_pattern(Some("demo:"), true, "sa:*"),
+            "demo:*"
+        );
+        assert_eq!(apply_storage_prefix_to_pattern(None, false, "sa:*"), "sa:*");
+    }
+
+    #[test]
+    fn strips_prefix_from_key() {
+        assert_eq!(
+            strip_storage_prefix(Some("demo:"), false, "demo:sa:token:abc"),
+            "sa:token:abc"
+        );
+        assert_eq!(
+            strip_storage_prefix(Some("demo:"), true, "demo:token:abc"),
+            "sa:token:abc"
+        );
+        assert_eq!(
+            strip_storage_prefix(Some("demo:"), true, "sa:token:abc"),
+            "sa:token:abc"
+        );
+        assert_eq!(
+            strip_storage_prefix(None, false, "sa:token:abc"),
+            "sa:token:abc"
+        );
     }
 }

--- a/summer-sa-token/tests/config_test.rs
+++ b/summer-sa-token/tests/config_test.rs
@@ -17,6 +17,8 @@ fn test_sa_token_config_creation() {
         is_read_header: true,
         is_read_body: false,
         token_prefix: Some("Bearer ".to_string()),
+        storage_prefix: None,
+        rewrite_storage_prefix: false,
         jwt_secret_key: None,
         jwt_algorithm: Some("HS256".to_string()),
         jwt_issuer: None,
@@ -110,6 +112,36 @@ fn test_sa_token_config_with_prefix() {
     };
 
     assert_eq!(config.token_prefix, Some("Bearer ".to_string()));
+}
+
+#[test]
+fn test_sa_token_config_with_storage_prefix() {
+    let toml_str = r#"
+        token_name = "Authorization"
+        storage_prefix = "demo:"
+    "#;
+
+    let config: Result<SaTokenConfig, _> = toml::from_str(toml_str);
+    assert!(config.is_ok());
+
+    let config = config.unwrap();
+    assert_eq!(config.storage_prefix, Some("demo:".to_string()));
+}
+
+#[test]
+fn test_sa_token_config_with_rewrite_storage_prefix() {
+    let toml_str = r#"
+        token_name = "Authorization"
+        storage_prefix = "demo:"
+        rewrite_storage_prefix = true
+    "#;
+
+    let config: Result<SaTokenConfig, _> = toml::from_str(toml_str);
+    assert!(config.is_ok());
+
+    let config = config.unwrap();
+    assert_eq!(config.storage_prefix, Some("demo:".to_string()));
+    assert!(config.rewrite_storage_prefix);
 }
 
 #[test]

--- a/summer-sa-token/tests/integration_test.rs
+++ b/summer-sa-token/tests/integration_test.rs
@@ -3,10 +3,11 @@
 //! Uses AppBuilder and Plugin pattern for proper initialization
 
 use sa_token_core::token::TokenValue;
+use std::time::{SystemTime, UNIX_EPOCH};
 use summer::app::AppBuilder;
 use summer::async_trait;
 use summer::plugin::{ComponentRegistry, MutableComponentRegistry, Plugin};
-use summer_sa_token::{OptionalSaTokenExtractor, SaTokenLayer, SaTokenState, StpUtil};
+use summer_sa_token::{OptionalSaTokenExtractor, SaStorage, SaTokenLayer, SaTokenState, StpUtil};
 use summer_web::axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -15,6 +16,12 @@ use summer_web::axum::{
     Router,
 };
 use tower::ServiceExt;
+
+#[cfg(feature = "with-summer-redis")]
+use summer_sa_token::storage::SummerRedisStorage;
+
+#[cfg(feature = "with-summer-redis")]
+use summer_redis::redis::AsyncCommands;
 
 /// Test plugin that initializes SaTokenState for testing
 struct TestSaTokenPlugin;
@@ -200,6 +207,107 @@ async fn test_sa_token_integration() {
 
         assert_eq!(response.status(), StatusCode::OK);
     }
+}
+
+#[cfg(feature = "with-summer-redis")]
+async fn create_redis_connection() -> Option<summer_redis::Redis> {
+    let url = std::env::var("REDIS_URL").ok()?;
+    let client = summer_redis::redis::Client::open(url).expect("redis client should open");
+    Some(
+        client
+            .get_connection_manager()
+            .await
+            .expect("redis connection manager should connect"),
+    )
+}
+
+#[cfg(feature = "with-summer-redis")]
+fn unique_storage_prefix(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be after epoch")
+        .as_nanos();
+    format!("demo-{tag}-{nanos}")
+}
+
+#[cfg(feature = "with-summer-redis")]
+#[tokio::test]
+async fn test_redis_storage_rewrites_prefix_for_physical_keys() {
+    let Some(mut redis) = create_redis_connection().await else {
+        eprintln!("skipping: REDIS_URL is not set");
+        return;
+    };
+    let prefix = unique_storage_prefix("rewrite");
+    let storage = SummerRedisStorage::new(redis.clone(), Some(prefix.clone()), true);
+
+    storage.clear().await.expect("clear should succeed");
+
+    storage
+        .set("sa:login:token:user1", "token-123", None)
+        .await
+        .expect("set should succeed");
+
+    let rewritten_key = format!("{prefix}:login:token:user1");
+    let raw: Option<String> = redis
+        .get(&rewritten_key)
+        .await
+        .expect("prefixed key should be readable");
+    assert_eq!(raw.as_deref(), Some("token-123"));
+
+    let legacy_key = format!("{prefix}:sa:login:token:user1");
+    let old_raw: Option<String> = redis
+        .get(&legacy_key)
+        .await
+        .expect("old prefixed key should be readable");
+    assert!(old_raw.is_none());
+
+    storage.clear().await.expect("clear should succeed");
+}
+
+#[cfg(feature = "with-summer-redis")]
+#[tokio::test]
+async fn test_redis_storage_keys_and_clear_work_with_rewritten_prefix() {
+    let Some(mut redis) = create_redis_connection().await else {
+        eprintln!("skipping: REDIS_URL is not set");
+        return;
+    };
+    let prefix = unique_storage_prefix("keys");
+    let storage = SummerRedisStorage::new(redis.clone(), Some(prefix.clone()), true);
+
+    storage.clear().await.expect("clear should succeed");
+
+    redis
+        .set::<_, _, ()>(format!("{prefix}:token:one"), "a")
+        .await
+        .expect("set should succeed");
+    redis
+        .set::<_, _, ()>(format!("{prefix}:session:user1"), "b")
+        .await
+        .expect("set should succeed");
+    redis
+        .set::<_, _, ()>(format!("{prefix}:refresh:token-1"), "c")
+        .await
+        .expect("set should succeed");
+
+    let mut keys = storage.keys("sa:*").await.expect("keys should succeed");
+    keys.sort();
+
+    assert_eq!(
+        keys,
+        vec![
+            "sa:refresh:token-1".to_string(),
+            "sa:session:user1".to_string(),
+            "sa:token:one".to_string()
+        ]
+    );
+
+    storage.clear().await.expect("clear should succeed");
+
+    let remaining: Vec<String> = redis
+        .keys(format!("{prefix}:*"))
+        .await
+        .expect("keys should succeed");
+    assert!(remaining.is_empty());
 }
 
 mod test_config_conversion {


### PR DESCRIPTION
## Summary

Adds Redis storage key prefix support for `summer-sa-token` when using the `with-summer-redis` feature.

Closes #235

## Changes

- add `storage_prefix` config for Redis-backed sa-token storage
- add `rewrite_storage_prefix` config to optionally rewrite the upstream hardcoded `sa:` root
- normalize `storage_prefix` automatically, so `demo` becomes `demo:`
- translate logical sa-token keys at the storage adapter boundary
- restore logical `sa:*` keys correctly for `keys()` and `clear()`
- add config tests and Redis integration coverage
- document the new configuration in English and Chinese README files
- bump `summer-sa-token` version to `0.5.1`

## Notes

Upstream `sa-token-core` hardcodes the logical storage root as `sa:` and does not expose it as a configurable option.
Because of that, this PR handles prefixing and optional rewriting in the `summer-sa-token` storage adapter layer.
