### PR TITLE
Pubsub plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "summer-postgres",
     "summer-sea-orm",
     "summer-stream",
+    "summer-pubsub",
     "summer-mail",
     "summer-opentelemetry",
     "summer-opendal",
@@ -47,6 +48,9 @@ chrono = "0.4"
 dashmap = "6.1"
 dotenvy = "0.15.7"
 futures-util = "0.3"
+google-cloud-auth = "1.9"
+google-cloud-pubsub = "0.33"
+bytes = "1"
 http = "1"
 http-body = "1"
 indexmap = "2.13"

--- a/docs/content/docs/plugins/summer-pubsub.md
+++ b/docs/content/docs/plugins/summer-pubsub.md
@@ -1,0 +1,15 @@
++++
+title = "summer-pubsub Plugin"
+description = "How to use the summer-pubsub plugin"
+draft = false
+weight = 12
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "summer-pubsub is based on <a href='https://github.com/googleapis/google-cloud-rust' target='_blank'>google-cloud-rust</a>"
+toc = true
+top = false
++++
+
+{{ include(path="../../summer-pubsub/README.md") }}

--- a/docs/content/docs/plugins/summer-pubsub.zh.md
+++ b/docs/content/docs/plugins/summer-pubsub.zh.md
@@ -1,0 +1,15 @@
++++
+title = "summer-pubsub插件"
+description = "summer-pubsub插件如何使用"
+draft = false
+weight = 19
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "summer-pubsub是基于<a href='https://github.com/googleapis/google-cloud-rust' target='_blank'>google-cloud-rust</a>实现的"
+toc = true
+top = false
++++
+
+{{ include(path="../../summer-pubsub/README.zh.md") }}

--- a/examples/pubsub-example/Cargo.toml
+++ b/examples/pubsub-example/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pubsub-example"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+schemars = "1.2"
+serde = { version = "1", features = ["derive"] }
+summer = { path = "../../summer" }
+summer-stream = { path = "../../summer-stream" }
+summer-web = { path = "../../summer-web" }
+summer-sqlx = { path = "../../summer-sqlx", features = ["postgres"] }
+summer-redis = { path = "../../summer-redis" }
+summer-pubsub = { path = "../../summer-pubsub" }
+tokio = { workspace = true, features = ["full", "tracing"] }

--- a/examples/pubsub-example/README.md
+++ b/examples/pubsub-example/README.md
@@ -1,0 +1,20 @@
+# Pubsub Example 
+
+For this example, we will use the Pubsub API to send and receive messages, so you need to have a Pubsub topic created and a service account with the necessary permissions.
+
+Then save the credentials to the `credentials.json` file and execute the docker compose to start the postgres database.
+
+```bash
+docker compose up -d
+```
+
+Then execute the following command to start the application.
+
+```bash
+cargo run
+```
+
+Visiting the endpoint `http://localhost:8080/auth/signup` will send a message to the Pubsub topic `users_created` and the consumer will receive the message.
+
+The `project_id` in the `config/app.toml` file must be the same as the project id of the credentials file.
+

--- a/examples/pubsub-example/compose.yaml
+++ b/examples/pubsub-example/compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:15.3-alpine
+    environment:
+      - POSTGRES_PASSWORD=xudjf23adj213
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+    ports:
+      - 5432:5432

--- a/examples/pubsub-example/config/app.toml
+++ b/examples/pubsub-example/config/app.toml
@@ -1,0 +1,16 @@
+[web]
+port = 8000
+graceful = true
+
+[web.openapi]
+doc_prefix = "/docs"
+info = { title = "pubsub example", version = "0.0.1" }
+
+[sqlx]
+uri = "postgres://postgres:xudjf23adj213@127.0.0.1:5432/postgres"
+
+[pubsub]
+enabled = true
+project_id = "summerrs-pubsub"
+credentials = "credentials.json" # path to the credentials file
+# The credentials could be obtained from the GCP console or from the command line

--- a/examples/pubsub-example/credentials.json
+++ b/examples/pubsub-example/credentials.json
@@ -1,0 +1,13 @@
+{
+    "type": "",
+    "project_id": "",
+    "private_key_id": "",
+    "private_key": "",
+    "client_email": "",
+    "client_id": "",
+    "auth_uri": "",
+    "token_uri": "",
+    "auth_provider_x509_cert_url": "",
+    "client_x509_cert_url": "",
+    "universe_domain": ""
+}

--- a/examples/pubsub-example/src/consumers/mod.rs
+++ b/examples/pubsub-example/src/consumers/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/examples/pubsub-example/src/consumers/user.rs
+++ b/examples/pubsub-example/src/consumers/user.rs
@@ -1,0 +1,30 @@
+use summer::extractor::Component;
+use summer::extractor::Config;
+use summer_pubsub::PubSubConfig;
+use summer_pubsub::pubsub_listener;
+use summer_pubsub::Message;
+use summer::tracing;
+use summer_sqlx::ConnectPool;
+
+#[pubsub_listener("users_created_listener")]
+async fn on_users_created_message(
+    Config(_pubsub_config): Config<PubSubConfig>, // You can import other configs here if you need
+    Component(_pool): Component<ConnectPool>,
+    msg: Message,
+) {
+    let payload = String::from_utf8(msg.data.to_vec()).unwrap_or("<binary>".to_string());
+
+    let user_id = msg.attributes.get("user_id").map(String::as_str).unwrap_or("unknown");
+    let email = msg.attributes.get("email").map(String::as_str).unwrap_or("unknown");
+    let created_at = msg.attributes.get("created_at").map(String::as_str).unwrap_or("unknown");
+
+    tracing::info!(
+        message_id = %msg.message_id,
+        len = msg.data.len(),
+        payload,
+        user_id,
+        email,
+        created_at,
+        "pubsub users_created (received)"
+    );
+}

--- a/examples/pubsub-example/src/controllers/auth.rs
+++ b/examples/pubsub-example/src/controllers/auth.rs
@@ -1,0 +1,42 @@
+use summer_web::nest;
+
+#[nest("/auth")]
+pub mod auth {
+    use summer_sqlx::ConnectPool;
+    use summer_web::axum::response::IntoResponse;
+    use summer_web::extractor::{Component, Config};
+    use summer_web::get;
+    use summer_pubsub::{PubSubConfig, PubSubProducer};
+    use summer_pubsub::model::Message;
+    use summer::tracing;
+    use summer_web::axum::http::StatusCode;
+    
+    #[get("/signup")]
+    pub async fn signup(
+        Config(_pubsub_config): Config<PubSubConfig>, // You can import other configs here if you need
+        Component(_pool): Component<ConnectPool>,
+        Component(pubsub): Component<PubSubProducer>,
+    ) -> impl IntoResponse {
+        tracing::info!("signup");
+
+        tracing::info!("You can use other components and configs here");
+
+
+        let user_id = "1234567890";
+        let email = "test@test.com";
+        let created_at = "2026-04-25T12:00:00Z";
+
+        let message = Message::new()
+            .set_data(user_id.as_bytes())
+            .set_attributes([
+                ("user_id".to_string(), user_id.to_string()),
+                ("email".to_string(), email.to_string()),
+                ("created_at".to_string(), created_at.to_string()),
+            ])
+            .set_ordering_key(user_id.to_string());
+        // publish a message to the pubsub topic "users_created"
+        let something = pubsub.publish("users_created", message).await;
+        tracing::info!(?something, "published signup message");
+        (StatusCode::OK, "Signup successful").into_response()
+    }
+}

--- a/examples/pubsub-example/src/controllers/mod.rs
+++ b/examples/pubsub-example/src/controllers/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/examples/pubsub-example/src/main.rs
+++ b/examples/pubsub-example/src/main.rs
@@ -1,0 +1,17 @@
+mod controllers;
+mod consumers;
+
+use summer::{App, auto_config};
+use summer_pubsub::PubSubPlugin;
+use summer_sqlx::SqlxPlugin;
+use summer_web::{WebConfigurator, WebPlugin};
+
+#[auto_config(WebConfigurator, PubSubConfigurator)]
+#[tokio::main]
+async fn main() {
+    App::new()
+        .add_plugin(WebPlugin)
+        .add_plugin(PubSubPlugin)
+        .add_plugin(SqlxPlugin)
+        .run().await;
+}

--- a/summer-macros/src/auto.rs
+++ b/summer-macros/src/auto.rs
@@ -152,7 +152,7 @@ fn add_method_call(call: ExprCall, args: &ConfigArgs) -> Expr {
     if args.pubsub {
         expr = syn::parse_quote! {
             ::summer_pubsub::PubSubConfigurator::add_consumer(
-                &mut #expr,
+                #expr,
                 ::summer_pubsub::handler::auto_consumers(),
             )
         };

--- a/summer-macros/src/auto.rs
+++ b/summer-macros/src/auto.rs
@@ -8,12 +8,14 @@ use syn::{ItemFn, Stmt, Token};
 struct ConfigArgs {
     route: bool,
     job: bool,
+    pubsub: bool,
 }
 
 impl syn::parse::Parse for ConfigArgs {
     fn parse(args: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut route = false;
         let mut job = false;
+        let mut pubsub = false;
 
         while !args.is_empty() {
             let ident = args.parse::<syn::Ident>().map_err(|mut err| {
@@ -30,13 +32,20 @@ impl syn::parse::Parse for ConfigArgs {
             if ident == "JobConfigurator" {
                 job = true;
             }
+            if ident == "PubSubConfigurator" {
+                pubsub = true;
+            }
             if !args.peek(Token![,]) {
                 break;
             }
             args.parse::<Token![,]>()?;
         }
 
-        Ok(ConfigArgs { route, job })
+        Ok(ConfigArgs {
+            route,
+            job,
+            pubsub,
+        })
     }
 }
 
@@ -139,6 +148,14 @@ fn add_method_call(call: ExprCall, args: &ConfigArgs) -> Expr {
                 punctuated
             },
         });
+    }
+    if args.pubsub {
+        expr = syn::parse_quote! {
+            ::summer_pubsub::PubSubConfigurator::add_consumer(
+                &mut #expr,
+                ::summer_pubsub::handler::auto_consumers(),
+            )
+        };
     }
     expr
 }

--- a/summer-macros/src/lib.rs
+++ b/summer-macros/src/lib.rs
@@ -15,6 +15,7 @@ mod route;
 #[cfg(feature = "socket_io")]
 mod socketioxide;
 mod stream;
+mod pubsub;
 mod utils;
 
 #[cfg(feature = "sa-token")]
@@ -288,8 +289,9 @@ job_macro!(Cron, cron, "1/10 * * * * *");
 ///  use summer_macros::auto_config;
 ///  use summer_web::{WebPlugin, WebConfigurator};
 ///  use summer_job::{JobPlugin, JobConfigurator};
+///  use summer_pubsub::{PubSubPlugin, PubSubConfigurator};
 ///  use summer_boot::app::App;
-/// +#[auto_config(WebConfigurator, JobConfigurator)]
+/// +#[auto_config(WebConfigurator, JobConfigurator, PubSubConfigurator)]
 ///  #[tokio::main]
 ///  async fn main() {
 ///      App::new()
@@ -311,6 +313,12 @@ pub fn auto_config(args: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn stream_listener(args: TokenStream, input: TokenStream) -> TokenStream {
     stream::listener(args, input)
+}
+
+/// Google Cloud Pub/Sub listener (subscription id or full resource name).
+#[proc_macro_attribute]
+pub fn pubsub_listener(args: TokenStream, input: TokenStream) -> TokenStream {
+    pubsub::listener(args, input)
 }
 
 /// Configurable

--- a/summer-macros/src/pubsub.rs
+++ b/summer-macros/src/pubsub.rs
@@ -86,7 +86,7 @@ impl ToTokens for PubsubListener {
                     #ast
 
                     consumers.add_consumer(
-                        ::summer_pubsub::consumer::Consumer::default()
+                        ::summer_pubsub::consumer::ConsumerOpts::default()
                             .consume(#subscription, #name)
                     )
                 }

--- a/summer-macros/src/pubsub.rs
+++ b/summer-macros/src/pubsub.rs
@@ -1,0 +1,115 @@
+use crate::input_and_compile_error;
+use proc_macro::TokenStream;
+use quote::quote;
+use quote::ToTokens;
+use syn::{ItemFn, LitStr, Token};
+
+struct PubsubListenerArgs {
+    subscription: LitStr,
+}
+
+impl syn::parse::Parse for PubsubListenerArgs {
+    fn parse(args: syn::parse::ParseStream) -> syn::Result<Self> {
+        let subscription = args.parse::<LitStr>().map_err(|mut err| {
+            err.combine(syn::Error::new(
+                err.span(),
+                r#"invalid pubsub_listener, expected #[pubsub_listener("subscription-id")]"#,
+            ));
+            err
+        })?;
+        if args.peek(Token![,]) {
+            args.parse::<Token![,]>()?;
+        }
+        if !args.is_empty() {
+            return Err(syn::Error::new(
+                args.span(),
+                "pubsub_listener only accepts a single subscription literal for now",
+            ));
+        }
+        Ok(Self { subscription })
+    }
+}
+
+pub(crate) struct PubsubListener {
+    name: syn::Ident,
+    args: PubsubListenerArgs,
+    ast: syn::ItemFn,
+    doc_attributes: Vec<syn::Attribute>,
+}
+
+impl PubsubListener {
+    fn new(args: PubsubListenerArgs, ast: ItemFn) -> syn::Result<Self> {
+        let name = ast.sig.ident.clone();
+        let doc_attributes = ast
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("doc"))
+            .cloned()
+            .collect();
+
+        if ast.sig.asyncness.is_none() {
+            return Err(syn::Error::new_spanned(
+                ast.sig.fn_token,
+                "only support async fn",
+            ));
+        }
+
+        Ok(Self {
+            name,
+            args,
+            ast,
+            doc_attributes,
+        })
+    }
+}
+
+impl ToTokens for PubsubListener {
+    fn to_tokens(&self, output: &mut proc_macro2::TokenStream) {
+        let Self {
+            name,
+            ast,
+            args,
+            doc_attributes,
+        } = self;
+        #[allow(unused_variables)]
+        let vis = &ast.vis;
+        let subscription = &args.subscription;
+
+        let stream = quote! {
+            #(#doc_attributes)*
+            #[allow(non_camel_case_types, missing_docs)]
+            #vis struct #name;
+
+            impl ::summer_pubsub::handler::TypedHandlerRegistrar for #name {
+                fn install_consumer(&self, mut consumers: ::summer_pubsub::Consumers) -> ::summer_pubsub::Consumers {
+                    use ::summer_pubsub::PubSubConfigurator;
+                    #ast
+
+                    consumers.add_consumer(
+                        ::summer_pubsub::consumer::Consumer::default()
+                            .consume(#subscription, #name)
+                    )
+                }
+            }
+
+            ::summer_pubsub::submit_typed_handler!(#name);
+        };
+
+        output.extend(stream);
+    }
+}
+
+pub(crate) fn listener(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args: PubsubListenerArgs = match syn::parse(args) {
+        Ok(config) => config,
+        Err(e) => return input_and_compile_error(input, e),
+    };
+    let ast = match syn::parse::<syn::ItemFn>(input.clone()) {
+        Ok(ast) => ast,
+        Err(err) => return input_and_compile_error(input, err),
+    };
+    match PubsubListener::new(args, ast) {
+        Ok(job) => job.into_token_stream().into(),
+        Err(err) => input_and_compile_error(input, err),
+    }
+}

--- a/summer-pubsub/CHANGELOG.md
+++ b/summer-pubsub/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.5.0
+
+- first release of the pubsub plugin, this include a macro to create pubsub listeners and a component to publish messages to the pubsub topic.

--- a/summer-pubsub/Cargo.toml
+++ b/summer-pubsub/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "summer-pubsub"
+description = "Integrate Google Cloud Pub/Sub (google-cloud-pubsub) with summer-rs"
+version = "0.5.0"
+categories = ["network-programming"]
+keywords = ["pubsub", "gcp", "google-cloud", "summer"]
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+summer = { path = "../summer", version = "0.5" }
+summer-macros = { path = "../summer-macros", version = "0.5" }
+google-cloud-pubsub = { workspace = true }
+google-cloud-auth = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
+inventory = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+async-trait = { workspace = true }
+bytes = { workspace = true }

--- a/summer-pubsub/README.md
+++ b/summer-pubsub/README.md
@@ -1,0 +1,79 @@
+[![crates.io](https://img.shields.io/crates/v/summer-pubsub.svg)](https://crates.io/crates/summer-pubsub)
+[![Documentation](https://docs.rs/summer-pubsub/badge.svg)](https://docs.rs/summer-pubsub)
+
+[google-cloud-pubsub](https://github.com/googleapis/google-cloud-rust) is a library for interacting with the Google Cloud Pub/Sub API.
+
+## Dependencies
+
+```toml
+summer-pubsub = { version = "<version>" }
+```
+
+## Configuration items
+
+```toml
+[pubsub]
+enabled = true # Whether to enable the pubsub plugin, default true
+project_id = "your-project-id" # The project id of the google cloud project
+credentials = "path/to/credentials.json" # The path to the credentials file
+endpoint = "https://pubsub.googleapis.com" # The endpoint of the pubsub api in case you are using the pubsub emulator
+```
+
+The credentials file is a JSON file that contains the credentials to access the pubsub api. You can get the credentials file from the Google Cloud Console.
+
+## Components
+
+When the plugin is enabled, it will automatically register a `PubSubSubscriber` component.
+
+`PubSubProducer` is a component that allows you to publish messages to the pubsub topic.
+
+Besides you can create a handler for each subscription and register it to the app.
+
+```rust
+#[pubsub_listener("users_created_listener")]
+async fn on_users_created_message(msg: Message) {
+    println!("Received message: {:?}", msg);
+}
+```
+
+On the handler, you can use `Component` to extract the components registered in the app or configs using `Config`.
+
+```rust
+use summer::extractor::{Component, Config};
+use summer_pubsub::{PubSubConfig, pubsub_listener, Message};
+use summer_sqlx::ConnectPool;
+
+#[pubsub_listener("users_created_listener")]
+async fn on_users_created_message(
+    Config(_pubsub_config): Config<PubSubConfig>, // You can import other configs here if you need
+    msg: Message,
+    Component(_pool): Component<ConnectPool>,
+) {
+    println!("Received message: {:?}", msg);
+}
+```
+
+The order of the parameters is not important in the handler, you can use the parameters in the handler as you like.
+
+You can combine the `PubSubProducer` in web handler to publish messages to the pubsub topic.
+
+```rust
+use summer_web::axum::response::IntoResponse;
+use summer_web::extractor::Component;
+use summer_web::get;
+use summer_pubsub::{PubSubProducer};
+use summer_pubsub::model::Message;
+
+#[get("/pubsub")]
+async fn pubsub(
+    Component(producer): Component<PubSubProducer>,
+) -> impl IntoResponse {
+    
+    let message = Message::new()
+        .set_data("Hello, world!".as_bytes());
+    
+    producer.publish("users_created", message).await;
+
+    (StatusCode::OK, "Message published").into_response()
+}
+```

--- a/summer-pubsub/README.zh.md
+++ b/summer-pubsub/README.zh.md
@@ -1,0 +1,79 @@
+[![crates.io](https://img.shields.io/crates/v/summer-pubsub.svg)](https://crates.io/crates/summer-pubsub)
+[![Documentation](https://docs.rs/summer-pubsub/badge.svg)](https://docs.rs/summer-pubsub)
+
+[google-cloud-pubsub](https://github.com/googleapis/google-cloud-rust) 是一个用于与 Google Cloud Pub/Sub API 交互的库。
+
+## 依赖
+
+```toml
+summer-pubsub = { version = "<version>" }
+```
+
+## 配置项
+
+```toml
+[pubsub]
+enabled = true # 是否启用 pubsub 插件，默认 true
+project_id = "your-project-id" # Google Cloud 项目的 project id
+credentials = "path/to/credentials.json" # 凭证文件路径
+endpoint = "https://pubsub.googleapis.com" # 如果使用 pubsub 模拟器，可指定 API endpoint
+```
+
+凭证文件是一个 JSON 文件，包含访问 pubsub API 所需的认证信息。你可以从 Google Cloud Console 获取该文件。
+
+## 组件
+
+当插件启用时，会自动注册一个 `PubSubSubscriber` 组件。
+
+`PubSubProducer` 是一个用于向 pubsub topic 发布消息的组件。
+
+此外，你可以为每个订阅创建一个 handler，并将其注册到应用中。
+
+```rust
+#[pubsub_listener("users_created_listener")]
+async fn on_users_created_message(msg: Message) {
+    println!("Received message: {:?}", msg);
+}
+```
+
+在 handler 中，你可以使用 `Component` 提取应用中注册的组件，或者使用 `Config` 获取配置。
+
+```rust
+use summer::extractor::{Component, Config};
+use summer_pubsub::{PubSubConfig, pubsub_listener, Message};
+use summer_sqlx::ConnectPool;
+
+#[pubsub_listener("users_created_listener")]
+async fn on_users_created_message(
+    Config(_pubsub_config): Config<PubSubConfig>, // 如果需要，可以在这里引入其他配置
+    msg: Message,
+    Component(_pool): Component<ConnectPool>,
+) {
+    println!("Received message: {:?}", msg);
+}
+```
+
+handler 中参数的顺序并不重要，你可以根据需要自由排列。
+
+你也可以在 Web handler 中结合使用 `PubSubProducer`，向 pubsub topic 发布消息。
+
+```rust
+use summer_web::axum::response::IntoResponse;
+use summer_web::extractor::Component;
+use summer_web::get;
+use summer_pubsub::{PubSubProducer};
+use summer_pubsub::model::Message;
+
+#[get("/pubsub")]
+async fn pubsub(
+    Component(producer): Component<PubSubProducer>,
+) -> impl IntoResponse {
+    
+    let message = Message::new()
+        .set_data("Hello, world!".as_bytes());
+    
+    producer.publish("users_created", message).await;
+
+    (StatusCode::OK, "Message published").into_response()
+}
+```

--- a/summer-pubsub/src/config.rs
+++ b/summer-pubsub/src/config.rs
@@ -1,0 +1,59 @@
+use anyhow::Context;
+use google_cloud_auth::credentials::{
+    Credentials, external_account, impersonated, service_account, user_account,
+};
+use google_cloud_auth::credentials::AccessTokenCredentials;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use summer::config::Configurable;
+
+summer::submit_config_schema!("pubsub", PubSubConfig);
+
+#[derive(Debug, Configurable, Clone, JsonSchema, Deserialize)]
+#[config_prefix = "pubsub"]
+pub struct PubSubConfig {
+    /// When false, the plugin does not connect to Pub/Sub or register consumers.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// GCP project id used to expand short subscription and topic names.
+    pub project_id: String,
+    /// Optional API endpoint (for example the Pub/Sub emulator).
+    pub endpoint: Option<String>,
+    /// Optional path to a service account or ADC JSON key file.
+    pub credentials: Option<String>,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+pub fn credentials_from_json_value(json: Value) -> anyhow::Result<Credentials> {
+    let cred_type = json
+        .get("type")
+        .and_then(|v| v.as_str())
+        .context("credential JSON missing string field `type`")?;
+    let atc: AccessTokenCredentials = match cred_type {
+        "authorized_user" => user_account::Builder::new(json)
+            .build_access_token_credentials()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        "service_account" => service_account::Builder::new(json)
+            .build_access_token_credentials()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        "external_account" => external_account::Builder::new(json)
+            .build_access_token_credentials()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        "impersonated_service_account" => impersonated::Builder::new(json)
+            .build_access_token_credentials()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        other => anyhow::bail!("unsupported credential type: {other}"),
+    };
+    Ok(atc.into())
+}
+
+pub fn credentials_from_file(path: &str) -> anyhow::Result<Credentials> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("read pubsub credentials file {path}"))?;
+    let json: Value = serde_json::from_str(&raw).context("parse credentials JSON")?;
+    credentials_from_json_value(json)
+}

--- a/summer-pubsub/src/consumer.rs
+++ b/summer-pubsub/src/consumer.rs
@@ -45,10 +45,6 @@ pub struct Consumer {
 pub struct ConsumerOpts;
 
 impl Consumer {
-    pub fn default() -> ConsumerOpts {
-        ConsumerOpts
-    }
-
     pub(crate) fn new_instance(&self, project_id: &str) -> ConsumerInstance {
         ConsumerInstance {
             subscription: resolve_subscription(project_id, self.subscription_literal),

--- a/summer-pubsub/src/consumer.rs
+++ b/summer-pubsub/src/consumer.rs
@@ -3,6 +3,7 @@ use google_cloud_pubsub::client::Subscriber;
 use summer::app::App;
 use summer::error::Result;
 use summer::plugin::ComponentRegistry;
+use summer::signal;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -84,8 +85,21 @@ impl ConsumerInstance {
             "summer-pubsub: Subscriber component missing; add PubSubPlugin before consumers run",
         );
         let mut stream = subscriber.subscribe(subscription.as_str()).build();
+        let shutdown = signal::shutdown_signal("pubsub consumer");
+        tokio::pin!(shutdown);
+
         loop {
-            let next = stream.next().await;
+            let next = tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    tracing::info!(
+                        "pubsub subscription {subscription}: shutdown signal received, stopping consumer"
+                    );
+                    break;
+                }
+                n = stream.next() => n,
+            };
+
             let Some(result) = next else {
                 tracing::warn!("pubsub subscription {subscription}: stream closed");
                 break;

--- a/summer-pubsub/src/consumer.rs
+++ b/summer-pubsub/src/consumer.rs
@@ -1,0 +1,121 @@
+use crate::handler::{BoxedHandler, HandlerArgs, PubSubEnvelope};
+use google_cloud_pubsub::client::Subscriber;
+use summer::app::App;
+use summer::error::Result;
+use summer::plugin::ComponentRegistry;
+use std::ops::Deref;
+use std::sync::Arc;
+
+#[derive(Clone, Default)]
+pub struct Consumers(Vec<Consumer>);
+
+impl Consumers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_consumer(mut self, consumer: Consumer) -> Self {
+        self.0.push(consumer);
+        self
+    }
+
+    pub(crate) fn merge(&mut self, consumers: Self) {
+        for consumer in consumers.0 {
+            self.0.push(consumer);
+        }
+    }
+}
+
+impl Deref for Consumers {
+    type Target = Vec<Consumer>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
+pub struct Consumer {
+    pub(crate) subscription_literal: &'static str,
+    pub(crate) handler: BoxedHandler,
+}
+
+#[derive(Clone, Default)]
+pub struct ConsumerOpts;
+
+impl Consumer {
+    pub fn default() -> ConsumerOpts {
+        ConsumerOpts
+    }
+
+    pub(crate) fn new_instance(&self, project_id: &str) -> ConsumerInstance {
+        ConsumerInstance {
+            subscription: resolve_subscription(project_id, self.subscription_literal),
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl ConsumerOpts {
+    pub fn consume<H, A>(self, subscription: &'static str, handler: H) -> Consumer
+    where
+        H: HandlerArgs<A> + Sync,
+        A: 'static,
+    {
+        Consumer {
+            handler: BoxedHandler::from_handler(handler),
+            subscription_literal: subscription,
+        }
+    }
+}
+
+pub(crate) struct ConsumerInstance {
+    subscription: String,
+    handler: BoxedHandler,
+}
+
+impl ConsumerInstance {
+    pub async fn schedule(self, app: Arc<App>) -> Result<String> {
+        let ConsumerInstance {
+            subscription,
+            handler,
+        } = self;
+        let subscriber = app.get_component::<Subscriber>().expect(
+            "summer-pubsub: Subscriber component missing; add PubSubPlugin before consumers run",
+        );
+        let mut stream = subscriber.subscribe(subscription.as_str()).build();
+        loop {
+            let next = stream.next().await;
+            let Some(result) = next else {
+                tracing::warn!("pubsub subscription {subscription}: stream closed");
+                break;
+            };
+            let (grpc, h) = match result {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(?e, "pubsub subscription {subscription}: stream error");
+                    break;
+                }
+            };
+            let env = PubSubEnvelope::new(h);
+            BoxedHandler::call(handler.clone(), grpc, env, app.clone()).await;
+        }
+        Ok(format!("pubsub consumer {subscription} stopped"))
+    }
+}
+
+pub fn resolve_subscription(project_id: &str, literal: &str) -> String {
+    if literal.starts_with("projects/") && literal.contains("/subscriptions/") {
+        literal.to_string()
+    } else {
+        format!("projects/{project_id}/subscriptions/{literal}")
+    }
+}
+
+pub fn resolve_topic(project_id: &str, literal: &str) -> String {
+    if literal.starts_with("projects/") && literal.contains("/topics/") {
+        literal.to_string()
+    } else {
+        format!("projects/{project_id}/topics/{literal}")
+    }
+}

--- a/summer-pubsub/src/extractor.rs
+++ b/summer-pubsub/src/extractor.rs
@@ -24,6 +24,7 @@ impl FromPubSubMsg for Message {
         Message::new(
             grpc.message_id.clone(),
             grpc.data.clone(),
+            grpc.attributes.clone(),
             env.ack.clone(),
         )
     }

--- a/summer-pubsub/src/extractor.rs
+++ b/summer-pubsub/src/extractor.rs
@@ -1,0 +1,61 @@
+use crate::handler::PubSubEnvelope;
+use crate::message::Message;
+use summer::app::App;
+use summer::config::Configurable;
+use summer::config::ConfigRegistry;
+use summer::extractor::Component;
+use summer::extractor::Config;
+use summer::plugin::ComponentRegistry;
+
+pub trait FromPubSubMsg: Sized {
+    fn from_pubsub(
+        grpc: &google_cloud_pubsub::model::Message,
+        env: &PubSubEnvelope,
+        app: &App,
+    ) -> Self;
+}
+
+impl FromPubSubMsg for Message {
+    fn from_pubsub(
+        grpc: &google_cloud_pubsub::model::Message,
+        env: &PubSubEnvelope,
+        _app: &App,
+    ) -> Self {
+        Message::new(
+            grpc.message_id.clone(),
+            grpc.data.clone(),
+            env.ack.clone(),
+        )
+    }
+}
+
+impl<T> FromPubSubMsg for Component<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    fn from_pubsub(_grpc: &google_cloud_pubsub::model::Message, _env: &PubSubEnvelope, app: &App) -> Self {
+        match app.get_component_ref::<T>() {
+            Some(component) => Component(T::clone(&component)),
+            None => panic!(
+                "There is no component of `{}` type",
+                std::any::type_name::<T>()
+            ),
+        }
+    }
+}
+
+impl<T> FromPubSubMsg for Config<T>
+where
+    T: serde::de::DeserializeOwned + Configurable,
+{
+    fn from_pubsub(_grpc: &google_cloud_pubsub::model::Message, _env: &PubSubEnvelope, app: &App) -> Self {
+        match app.get_config::<T>() {
+            Ok(config) => Config(config),
+            Err(e) => panic!(
+                "get config failed for typeof {}: {}",
+                std::any::type_name::<T>(),
+                e
+            ),
+        }
+    }
+}

--- a/summer-pubsub/src/handler.rs
+++ b/summer-pubsub/src/handler.rs
@@ -1,0 +1,217 @@
+pub use inventory::submit;
+
+use crate::consumer::Consumers;
+use crate::extractor::FromPubSubMsg;
+use google_cloud_pubsub::subscriber::handler::Handler;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use summer::app::App;
+
+/// Internal type surfaced only to the `FromPubSubMsg` machinery; do not rely on it in application code.
+#[doc(hidden)]
+pub struct PubSubEnvelope {
+    pub(crate) ack: Arc<Mutex<Option<Handler>>>,
+}
+
+impl PubSubEnvelope {
+    pub(crate) fn new(handler: Handler) -> Self {
+        Self {
+            ack: Arc::new(Mutex::new(Some(handler))),
+        }
+    }
+}
+
+impl Drop for PubSubEnvelope {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = self.ack.lock() {
+            if let Some(h) = slot.take() {
+                h.ack();
+            }
+        }
+    }
+}
+
+pub trait HandlerArgs<T>: Clone + Send + Sized + 'static {
+    type Future: Future<Output = ()> + Send + 'static;
+
+    fn call(self, grpc: google_cloud_pubsub::model::Message, env: PubSubEnvelope, app: Arc<App>) -> Self::Future;
+}
+
+impl<F, Fut> HandlerArgs<()> for F
+where
+    F: FnOnce() -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    type Future = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+    fn call(
+        self,
+        _grpc: google_cloud_pubsub::model::Message,
+        _env: PubSubEnvelope,
+        _app: Arc<App>,
+    ) -> Self::Future {
+        Box::pin(self())
+    }
+}
+
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!([T1]);
+        $name!([T1, T2]);
+        $name!([T1, T2, T3]);
+        $name!([T1, T2, T3, T4]);
+        $name!([T1, T2, T3, T4, T5]);
+        $name!([T1, T2, T3, T4, T5, T6]);
+        $name!([T1, T2, T3, T4, T5, T6, T7]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]);
+    };
+}
+
+macro_rules! impl_handler_args {
+    (
+        [$($ty:ident),*]
+    ) => {
+        #[allow(non_snake_case, unused_mut)]
+        impl<F, Fut, $($ty,)*> HandlerArgs<($($ty,)*)> for F
+        where
+            F: FnOnce($($ty,)*) -> Fut + Clone + Send + 'static,
+            Fut: Future<Output = ()> + Send + 'static,
+            $( $ty: FromPubSubMsg + Send, )*
+        {
+            type Future = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+            fn call(self, grpc: google_cloud_pubsub::model::Message, env: PubSubEnvelope, app: Arc<App>) -> Self::Future {
+                $(
+                    let $ty = $ty::from_pubsub(&grpc, &env, &app);
+                )*
+                Box::pin(self($($ty,)*))
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_handler_args);
+
+pub(crate) struct BoxedHandler(std::sync::Mutex<Box<dyn ErasedHandler>>);
+
+impl Clone for BoxedHandler {
+    fn clone(&self) -> Self {
+        Self(std::sync::Mutex::new(self.0.lock().unwrap().clone_box()))
+    }
+}
+
+impl BoxedHandler {
+    pub(crate) fn from_handler<H, T>(handler: H) -> Self
+    where
+        H: HandlerArgs<T> + Sync,
+        T: 'static,
+    {
+        Self(std::sync::Mutex::new(Box::new(MakeErasedHandler {
+            handler,
+            caller: |handler, grpc, env, app| Box::pin(H::call(handler, grpc, env, app)),
+        })))
+    }
+
+    pub(crate) fn call(
+        self,
+        grpc: google_cloud_pubsub::model::Message,
+        env: PubSubEnvelope,
+        app: Arc<App>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        self.0.into_inner().unwrap().call(grpc, env, app)
+    }
+}
+
+pub(crate) trait ErasedHandler: Send {
+    fn clone_box(&self) -> Box<dyn ErasedHandler>;
+
+    fn call(
+        self: Box<Self>,
+        grpc: google_cloud_pubsub::model::Message,
+        env: PubSubEnvelope,
+        app: Arc<App>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+}
+
+type HandlerCaller<H> = fn(
+    H,
+    google_cloud_pubsub::model::Message,
+    PubSubEnvelope,
+    Arc<App>,
+) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+
+pub(crate) struct MakeErasedHandler<H> {
+    pub(crate) handler: H,
+    pub(crate) caller: HandlerCaller<H>,
+}
+
+impl<H> Clone for MakeErasedHandler<H>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            caller: self.caller,
+        }
+    }
+}
+
+impl<H> ErasedHandler for MakeErasedHandler<H>
+where
+    H: Clone + Send + Sync + 'static,
+{
+    fn clone_box(&self) -> Box<dyn ErasedHandler> {
+        Box::new(self.clone())
+    }
+
+    fn call(
+        self: Box<Self>,
+        grpc: google_cloud_pubsub::model::Message,
+        env: PubSubEnvelope,
+        app: Arc<App>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        (self.caller)(self.handler, grpc, env, app)
+    }
+}
+
+pub trait TypedHandlerRegistrar: Send + Sync + 'static {
+    fn install_consumer(&self, jobs: Consumers) -> Consumers;
+}
+
+pub trait TypedConsumer {
+    fn typed_consumer<F: TypedHandlerRegistrar>(self, factory: F) -> Self;
+}
+
+impl TypedConsumer for Consumers {
+    fn typed_consumer<F: TypedHandlerRegistrar>(self, factory: F) -> Self {
+        factory.install_consumer(self)
+    }
+}
+
+inventory::collect!(&'static dyn TypedHandlerRegistrar);
+
+#[macro_export]
+macro_rules! submit_typed_handler {
+    ($ty:ident) => {
+        ::summer_pubsub::handler::submit! {
+            &$ty as &dyn ::summer_pubsub::handler::TypedHandlerRegistrar
+        }
+    };
+}
+
+pub fn auto_consumers() -> Consumers {
+    let mut consumers = Consumers::new();
+    for factory in inventory::iter::<&dyn TypedHandlerRegistrar> {
+        consumers = factory.install_consumer(consumers);
+    }
+    consumers
+}

--- a/summer-pubsub/src/lib.rs
+++ b/summer-pubsub/src/lib.rs
@@ -30,6 +30,8 @@ use summer::{
 use std::ops::Deref;
 use std::sync::Arc;
 
+pub use google_cloud_pubsub::*;
+
 pub trait PubSubConfigurator {
     fn add_consumer(&mut self, consumers: Consumers) -> &mut Self;
 }
@@ -63,13 +65,19 @@ impl Plugin for PubSubPlugin {
             return;
         }
 
+        let creds_opt = config
+            .credentials
+            .as_ref()
+            .map(|path| credentials_from_file(path))
+            .transpose()
+            .expect("summer-pubsub: load credentials failed");
+
         let mut sub_builder = Subscriber::builder();
         if let Some(endpoint) = &config.endpoint {
             sub_builder = sub_builder.with_endpoint(endpoint.clone());
         }
-        if let Some(path) = &config.credentials {
-            let creds = credentials_from_file(path).expect("summer-pubsub: load credentials failed");
-            sub_builder = sub_builder.with_credentials(creds);
+        if let Some(ref creds) = creds_opt {
+            sub_builder = sub_builder.with_credentials(creds.clone());
         }
 
         let subscriber = sub_builder
@@ -77,7 +85,11 @@ impl Plugin for PubSubPlugin {
             .await
             .expect("summer-pubsub: create Subscriber failed");
 
-        let producer = PubSubProducer::new(config.project_id.clone(), config.endpoint.clone());
+        let producer = PubSubProducer::new(
+            config.project_id.clone(),
+            config.endpoint.clone(),
+            creds_opt,
+        );
         app.add_component(subscriber.clone());
         app.add_component(producer);
 

--- a/summer-pubsub/src/lib.rs
+++ b/summer-pubsub/src/lib.rs
@@ -1,0 +1,97 @@
+//! [![summer-rs](https://img.shields.io/github/stars/summer-rs/summer-rs)](https://summer-rs.github.io/)
+#![doc(html_favicon_url = "https://summer-rs.github.io/favicon.ico")]
+#![doc(html_logo_url = "https://summer-rs.github.io/logo.svg")]
+
+pub mod config;
+pub mod consumer;
+pub mod extractor;
+pub mod handler;
+pub mod message;
+pub mod producer;
+
+pub use config::PubSubConfig;
+pub use consumer::{Consumer, ConsumerOpts, Consumers, resolve_subscription, resolve_topic};
+pub use google_cloud_pubsub;
+pub use handler::{TypedConsumer, TypedHandlerRegistrar, auto_consumers};
+pub use message::Message;
+pub use producer::PubSubProducer;
+pub use summer_macros::pubsub_listener;
+
+use config::credentials_from_file;
+use google_cloud_pubsub::client::Subscriber;
+use summer::async_trait;
+use summer::config::ConfigRegistry;
+use summer::plugin::component::ComponentRef;
+use summer::plugin::{ComponentRegistry, MutableComponentRegistry};
+use summer::{
+    app::{App, AppBuilder},
+    plugin::Plugin,
+};
+use std::ops::Deref;
+use std::sync::Arc;
+
+pub trait PubSubConfigurator {
+    fn add_consumer(&mut self, consumers: Consumers) -> &mut Self;
+}
+
+impl PubSubConfigurator for AppBuilder {
+    fn add_consumer(&mut self, new_consumers: Consumers) -> &mut Self {
+        if let Some(consumers) = self.get_component_ref::<Consumers>() {
+            unsafe {
+                let raw_ptr = ComponentRef::into_raw(consumers);
+                let consumers = &mut *(raw_ptr as *mut Consumers);
+                consumers.merge(new_consumers);
+            }
+            self
+        } else {
+            self.add_component(new_consumers)
+        }
+    }
+}
+
+pub struct PubSubPlugin;
+
+#[async_trait]
+impl Plugin for PubSubPlugin {
+    async fn build(&self, app: &mut AppBuilder) {
+        let config = app
+            .get_config::<PubSubConfig>()
+            .expect("summer-pubsub: config with prefix `pubsub` is required");
+
+        if !config.enabled {
+            tracing::info!("summer-pubsub: disabled by config (`pubsub.enabled = false`)");
+            return;
+        }
+
+        let mut sub_builder = Subscriber::builder();
+        if let Some(endpoint) = &config.endpoint {
+            sub_builder = sub_builder.with_endpoint(endpoint.clone());
+        }
+        if let Some(path) = &config.credentials {
+            let creds = credentials_from_file(path).expect("summer-pubsub: load credentials failed");
+            sub_builder = sub_builder.with_credentials(creds);
+        }
+
+        let subscriber = sub_builder
+            .build()
+            .await
+            .expect("summer-pubsub: create Subscriber failed");
+
+        let producer = PubSubProducer::new(config.project_id.clone(), config.endpoint.clone());
+        app.add_component(subscriber.clone());
+        app.add_component(producer);
+
+        if let Some(consumers) = app.get_component_ref::<Consumers>() {
+            for consumer in consumers.deref().iter() {
+                let instance = consumer.new_instance(config.project_id.as_str());
+                app.add_scheduler(|app: Arc<App>| Box::new(instance.schedule(app)));
+                tracing::info!(
+                    "summer-pubsub: register scheduler for subscription `{}`",
+                    consumer.subscription_literal
+                );
+            }
+        } else {
+            tracing::info!("summer-pubsub: no Consumers registered");
+        }
+    }
+}

--- a/summer-pubsub/src/message.rs
+++ b/summer-pubsub/src/message.rs
@@ -1,0 +1,49 @@
+use bytes::Bytes;
+use google_cloud_pubsub::subscriber::handler::Handler;
+use std::sync::{Arc, Mutex};
+
+/// Incoming Pub/Sub payload plus shared acknowledgement state.
+#[derive(Clone)]
+pub struct Message {
+    pub message_id: String,
+    pub data: Bytes,
+    ack: Arc<Mutex<Option<Handler>>>,
+}
+
+impl Message {
+    pub(crate) fn new(message_id: String, data: Bytes, ack: Arc<Mutex<Option<Handler>>>) -> Self {
+        Self {
+            message_id,
+            data,
+            ack,
+        }
+    }
+
+    /// Acknowledge this message (at-least-once best-effort semantics from the client library).
+    pub fn ack(&self) {
+        if let Ok(mut slot) = self.ack.lock() {
+            if let Some(h) = slot.take() {
+                h.ack();
+            }
+        }
+    }
+
+    /// Negative acknowledgement: the message may be redelivered.
+    pub fn nack(&self) {
+        if let Ok(mut slot) = self.ack.lock() {
+            if let Some(h) = slot.take() {
+                h.nack();
+            }
+        }
+    }
+}
+
+impl Drop for Message {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = self.ack.lock() {
+            if let Some(h) = slot.take() {
+                h.ack();
+            }
+        }
+    }
+}

--- a/summer-pubsub/src/message.rs
+++ b/summer-pubsub/src/message.rs
@@ -1,20 +1,28 @@
 use bytes::Bytes;
 use google_cloud_pubsub::subscriber::handler::Handler;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// Incoming Pub/Sub payload plus shared acknowledgement state.
+/// Incoming Pub/Sub payload plus shared acknowledgement state
 #[derive(Clone)]
 pub struct Message {
     pub message_id: String,
     pub data: Bytes,
+    pub attributes: HashMap<String, String>,
     ack: Arc<Mutex<Option<Handler>>>,
 }
 
 impl Message {
-    pub(crate) fn new(message_id: String, data: Bytes, ack: Arc<Mutex<Option<Handler>>>) -> Self {
+    pub(crate) fn new(
+        message_id: String,
+        data: Bytes,
+        attributes: HashMap<String, String>,
+        ack: Arc<Mutex<Option<Handler>>>,
+    ) -> Self {
         Self {
             message_id,
             data,
+            attributes,
             ack,
         }
     }

--- a/summer-pubsub/src/producer.rs
+++ b/summer-pubsub/src/producer.rs
@@ -1,6 +1,7 @@
 use crate::consumer::resolve_topic;
 use anyhow::Context;
 use bytes::Bytes;
+use google_cloud_auth::credentials::Credentials;
 use google_cloud_pubsub::client::Publisher;
 use google_cloud_pubsub::model::Message as GcpMessage;
 use std::collections::HashMap;
@@ -16,15 +17,21 @@ pub struct PubSubProducer {
 struct Inner {
     project_id: String,
     endpoint: Option<String>,
+    credentials: Option<Credentials>,
     publishers: Mutex<HashMap<String, Publisher>>,
 }
 
 impl PubSubProducer {
-    pub(crate) fn new(project_id: String, endpoint: Option<String>) -> Self {
+    pub(crate) fn new(
+        project_id: String,
+        endpoint: Option<String>,
+        credentials: Option<Credentials>,
+    ) -> Self {
         Self {
             inner: Arc::new(Inner {
                 project_id,
                 endpoint,
+                credentials,
                 publishers: Mutex::new(HashMap::new()),
             }),
         }
@@ -61,6 +68,9 @@ impl PubSubProducer {
         let mut b = Publisher::builder(full.clone());
         if let Some(ep) = &self.inner.endpoint {
             b = b.with_endpoint(ep.clone());
+        }
+        if let Some(ref creds) = self.inner.credentials {
+            b = b.with_credentials(creds.clone());
         }
         let publisher = b
             .build()

--- a/summer-pubsub/src/producer.rs
+++ b/summer-pubsub/src/producer.rs
@@ -1,0 +1,72 @@
+use crate::consumer::resolve_topic;
+use anyhow::Context;
+use bytes::Bytes;
+use google_cloud_pubsub::client::Publisher;
+use google_cloud_pubsub::model::Message as GcpMessage;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Publishes to Pub/Sub topics, caching one [`Publisher`] per fully-qualified topic name.
+#[derive(Clone)]
+pub struct PubSubProducer {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    project_id: String,
+    endpoint: Option<String>,
+    publishers: Mutex<HashMap<String, Publisher>>,
+}
+
+impl PubSubProducer {
+    pub(crate) fn new(project_id: String, endpoint: Option<String>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                project_id,
+                endpoint,
+                publishers: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Publish a fully constructed [`GcpMessage`] to `topic` (short id or full resource name).
+    pub async fn publish(&self, topic: &str, message: GcpMessage) -> anyhow::Result<String> {
+        let publisher = self.publisher_for(topic).await?;
+        publisher
+            .publish(message)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    /// Convenience helper: UTF-8 payload.
+    pub async fn publish_utf8(
+        &self,
+        topic: &str,
+        data: impl AsRef<str>,
+    ) -> anyhow::Result<String> {
+        self.publish(
+            topic,
+            GcpMessage::new().set_data(Bytes::copy_from_slice(data.as_ref().as_bytes())),
+        )
+        .await
+    }
+
+    async fn publisher_for(&self, topic: &str) -> anyhow::Result<Publisher> {
+        let full = resolve_topic(self.inner.project_id.as_str(), topic);
+        let mut map = self.inner.publishers.lock().await;
+        if let Some(p) = map.get(&full) {
+            return Ok(p.clone());
+        }
+        let mut b = Publisher::builder(full.clone());
+        if let Some(ep) = &self.inner.endpoint {
+            b = b.with_endpoint(ep.clone());
+        }
+        let publisher = b
+            .build()
+            .await
+            .context("build google_cloud_pubsub Publisher")?;
+        map.insert(full, publisher.clone());
+        Ok(publisher)
+    }
+}


### PR DESCRIPTION
Some pictures publishing the messages

<img width="1698" height="652" alt="image" src="https://github.com/user-attachments/assets/ea6abe8a-1513-4d16-a7a6-b2289b0ef458" />


<img width="1919" height="138" alt="image" src="https://github.com/user-attachments/assets/d3ed0c34-fcf2-4528-841c-e2d3c4c1bde7" />

This plugin is just something I was exploring because we use GCP at my job and I had some free time.

Maybe we should move some plugins like these to other repositories (I know there's already one, but I'd like your opinion), since they aren't really core. If we keep creating plugins, we might end up with one for Cloudflare, another for Azure, another for AWS, and so on. Perhaps there's a way to document them so people can discover them easily, while also addressing how this project scales as it grows.

